### PR TITLE
Astar logic update

### DIFF
--- a/PathPlanning/AStar/a_star.py
+++ b/PathPlanning/AStar/a_star.py
@@ -27,7 +27,7 @@ class Node:
         return str(self.x) + "," + str(self.y) + "," + str(self.cost) + "," + str(self.pind)
 
 
-def calc_fianl_path(ngoal, closedset, reso):
+def calc_final_path(ngoal, closedset, reso):
     # generate final course
     rx, ry = [ngoal.x * reso], [ngoal.y * reso]
     pind = ngoal.pind
@@ -105,10 +105,10 @@ def a_star_planning(sx, sy, gx, gy, ox, oy, reso, rr):
             if tcost >= node.cost:
                 continue  # this is not a better path
 
-            node.cost = tcost
-            openset[n_id] = node  # This path is the best unitl now. record it!
+            node.cost = tcost + calc_heuristic(node, ngoal)
+            openset[n_id] = node  # This path is the best until now. record it!
 
-    rx, ry = calc_fianl_path(ngoal, closedset, reso)
+    rx, ry = calc_final_path(ngoal, closedset, reso)
 
     return rx, ry
 


### PR DESCRIPTION
Correct the logic on successor node cost. The *f* cost the successor node should be *g* cost of successor node plus *h* cost to the **goal**. Here your *g* cost is the same as tentative (*t*) cost which is correct, however the *f* cost is not. More see in [pseudocode](http://mat.uab.cat/~alseda/MasterOpt/AStar-Algorithm.pdf)<sup>1</sup> and [psedocode](https://gist.github.com/damienstanton/7de65065bf584a43f96a#file-astar-txt-L25)<sup>2</sup>. 

Other correct are small typo corrections.

<sup>1</sup>: line 16

<sup>2</sup>: line 25

