### PR TITLE
add environment.yml to setup conda environment

### DIFF
--- a/PathPlanning/Eta3SplinePath/eta3_spline_path.py
+++ b/PathPlanning/Eta3SplinePath/eta3_spline_path.py
@@ -13,6 +13,7 @@ Ref:
 
 import numpy as np
 import matplotlib.pyplot as plt
+from scipy.integrate import quad
 
 # NOTE: *_pose is a 3-array: 0 - x coord, 1 - y coord, 2 - orientation angle \theta
 
@@ -151,6 +152,10 @@ class eta3_path_segment(object):
             + (10. * eta[1] - 2. * eta[3] + 1. / 6 * eta[5]) * sb \
             - (2. * eta[1]**2 * kappa[2] - 1. / 6 * eta[1]**3 *
                kappa[3] - 1. / 2 * eta[1] * eta[3] * kappa[2]) * cb
+        
+        s_dot = lambda u : np.linalg.norm(self.coeffs[:, 1:].dot(np.array([1, 2.*u, 3.*u**2, 4.*u**3, 5.*u**4, 6.*u**5, 7.*u**6])))
+        self.segment_length = quad(lambda u: s_dot(u), 0, 1)[0]
+
     """
     eta3_path_segment::calc_point
 
@@ -159,7 +164,6 @@ class eta3_path_segment(object):
     returns
         (x,y) of point along the segment
     """
-
     def calc_point(self, u):
         assert(u >= 0 and u <= 1)
         return self.coeffs.dot(np.array([1, u, u**2, u**3, u**4, u**5, u**6, u**7]))

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,9 @@
+name: python_robotics
+dependencies:
+- python==3.6
+- matplotlib
+- scipy
+- numpy
+- pandas
+- pip:
+    - cvxpy


### PR DESCRIPTION
This PR addresses the feature request I just created.  Users who prefer to use conda can setup their environments by navigating to the root of the PythonRobotics repo and typing: 

```
conda env create -f environment.yml
```

Then, to use the newly created `python_robotics` environment, they can type (from any directory):

```
source activate python_robotics
```

Also included in this PR (by mistake, but I was going to commit it anyways), is logic to compute the segment length in the `eta3_spline_path.py` code that was recently added.