### PR TITLE
fixed steer() in RRTstar

### DIFF
--- a/PathPlanning/RRTstar/rrt_star.py
+++ b/PathPlanning/RRTstar/rrt_star.py
@@ -102,12 +102,16 @@ class RRT():
         # expand tree
         nearestNode = self.nodeList[nind]
         theta = math.atan2(rnd[1] - nearestNode.y, rnd[0] - nearestNode.x)
-        newNode = copy.deepcopy(nearestNode)
-        newNode.x += self.expandDis * math.cos(theta)
-        newNode.y += self.expandDis * math.sin(theta)
-
-        newNode.cost += self.expandDis
-        newNode.parent = nind
+        newNode = Node(rnd[0], rnd[1])
+        currentDistance = math.sqrt( (rnd[1] - nearestNode.y) ** 2 +  (rnd[0] - nearestNode.x) ** 2)
+        # Find a point within expandDis of nind, and closest to rnd
+        if currentDistance <= self.expandDis:
+            pass
+        else:
+            newNode.x = nearestNode.x + self.expandDis * math.cos(theta)
+            newNode.y = nearestNode.y + self.expandDis * math.sin(theta)
+        newNode.cost = float("inf") 
+        newNode.parent = None
         return newNode
 
     def get_random_point(self):


### PR DESCRIPTION
Please check the [paper](https://core.ac.uk/download/pdf/18173530.pdf), 'Steer()' function in **Algorithm 6** is $steer(x, y) = argmin_{z \in B_{x, \eta}} \Vert z-y \Vert$ and x can be within that ball. Also the cost and parent will be determined by following procedures. 