### PR TITLE
Fixed a bug of calculating parameters in pure pursuit module

### DIFF
--- a/PathTracking/pure_pursuit/pure_pursuit.py
+++ b/PathTracking/pure_pursuit/pure_pursuit.py
@@ -85,7 +85,7 @@ def calc_target_index(state, cx, cy):
     # search look ahead target point index
     while Lf > L and (ind + 1) < len(cx):
         dx = cx[ind + 1] - cx[ind]
-        dy = cx[ind + 1] - cx[ind]
+        dy = cy[ind + 1] - cy[ind]
         L += math.sqrt(dx ** 2 + dy ** 2)
         ind += 1
 


### PR DESCRIPTION
I suppose this should be `cy` not `cx`.
I found it because this module didn't work correctly when the path was horizontal.