### PR TITLE
Fix & clean up EKF/UKF implementations

### DIFF
--- a/Localization/extended_kalman_filter/extended_kalman_filter.py
+++ b/Localization/extended_kalman_filter/extended_kalman_filter.py
@@ -36,13 +36,13 @@ def observation(xTrue, xd, u):
     xTrue = motion_model(xTrue, u)
 
     # add noise to gps x-y
-    zx = xTrue[0, 0] + np.random.randn() * Rsim[0, 0]
-    zy = xTrue[1, 0] + np.random.randn() * Rsim[1, 1]
+    zx = xTrue[0, 0] + np.random.randn() * Qsim[0, 0]
+    zy = xTrue[1, 0] + np.random.randn() * Qsim[1, 1]
     z = np.array([[zx, zy]]).T
 
     # add noise to input
-    ud1 = u[0, 0] + np.random.randn() * Qsim[0, 0]
-    ud2 = u[1, 0] + np.random.randn() * Qsim[1, 1]
+    ud1 = u[0, 0] + np.random.randn() * Rsim[0, 0]
+    ud2 = u[1, 0] + np.random.randn() * Rsim[1, 1]
     ud = np.array([[ud1, ud2]]).T
 
     xd = motion_model(xd, ud)

--- a/Localization/extended_kalman_filter/extended_kalman_filter.py
+++ b/Localization/extended_kalman_filter/extended_kalman_filter.py
@@ -62,7 +62,7 @@ def motion_model(x, u):
                   [0.0, DT],
                   [1.0, 0.0]])
 
-    x = F@x + B@u
+    x = F @ x + B @ u
 
     return x
 
@@ -74,7 +74,7 @@ def observation_model(x):
         [0, 1, 0, 0]
     ])
 
-    z = H@x
+    z = H @ x
 
     return z
 
@@ -120,16 +120,16 @@ def ekf_estimation(xEst, PEst, z, u):
     #  Predict
     xPred = motion_model(xEst, u)
     jF = jacobF(xPred, u)
-    PPred = jF@PEst@jF.T + Q
+    PPred = jF @ PEst @ jF.T + Q
 
     #  Update
     jH = jacobH(xPred)
     zPred = observation_model(xPred)
     y = z - zPred
-    S = jH@PPred@jH.T + R
-    K = PPred@jH.T@np.linalg.inv(S)
-    xEst = xPred + K@y
-    PEst = (np.eye(len(xEst)) - K@jH)@PPred
+    S = jH @ PPred @ jH.T + R
+    K = PPred @ jH.T @ np.linalg.inv(S)
+    xEst = xPred + K @ y
+    PEst = (np.eye(len(xEst)) - K @ jH) @ PPred
 
     return xEst, PEst
 
@@ -153,7 +153,7 @@ def plot_covariance_ellipse(xEst, PEst):  # pragma: no cover
     angle = math.atan2(eigvec[bigind, 1], eigvec[bigind, 0])
     R = np.array([[math.cos(angle), math.sin(angle)],
                   [-math.sin(angle), math.cos(angle)]])
-    fx = R@(np.array([x, y]))
+    fx = R @ np.array([x, y])
     px = np.array(fx[0, :] + xEst[0, 0]).flatten()
     py = np.array(fx[1, :] + xEst[1, 0]).flatten()
     plt.plot(px, py, "--r")

--- a/Localization/unscented_kalman_filter/unscented_kalman_filter.py
+++ b/Localization/unscented_kalman_filter/unscented_kalman_filter.py
@@ -32,8 +32,8 @@ show_animation = True
 
 def calc_input():
     v = 1.0  # [m/s]
-    yawRate = 0.1  # [rad/s]
-    u = np.array([[v, yawRate]]).T
+    yawrate = 0.1  # [rad/s]
+    u = np.array([[v, yawrate]]).T
     return u
 
 


### PR DESCRIPTION
Issues addressed in this PR:

In Kalman Filters

- **`Q`** is a square matrix with a size `N × N`, with `N` equal to the dimensions of the **state vector**.
- **`R`** is a square matrix with a size `M × M`, with `M` equal to the dimensions of the **output vector**.

## extended_kalman_filter.py

### Covariance matrices

In the EKF implementation …

- the state vector has `4` dimensions
- the output vector has `2` dimensions

As such `Qsim` would be expected to be of size `4 × 4`, yet was found to be of size `2 × 2`.

### Noise

Further more the noise was not applied correctly:

- `Q` is not to be applied to `u`, but to `x`, as it is the state (i.e. `x`) noise covariance
- `R` is not to be applied to `x`, but to `z`, as it is the state (i.e. `z`) noise covariance

## unscented_kalman_filter.py

### Covariance matrices

In the UKF implementation …

- the state vector has `4` dimensions
- the output vector has `2` dimensions

As such `Qsim` would be expected to be of size `4 × 4`, yet was found to be of size `2 × 2`.

Further more `Qsim` and `Rsim` seem to have been mixed up: The angle is a relevant part of the state not the output.

### Noise

Further more the noise was not applied correctly:

- `R` is not to be applied to `u`, but to `z`, as it is the state (i.e. `z`) noise covariance

## def observation(xTrue, xd, u):

In both cases the implementation of `def observation(…):` seems invalid to me.

It should be:

```python
def observation(xTrue, xd, u):

    xd = motion_model(xd, u)
    xTrue = motion_model(xTrue, u) + Qsim @ np.random.randn(4, 1)
    z = observation_model(xTrue) + Rsim @ np.random.randn(2, 1)

    return xTrue, xd, z
```

See the formulas from [Example application, technical](https://en.wikipedia.org/wiki/Kalman_filter#Example_application,_technical) on Wikipedia, specifically:

Where …

```python
xTrue = motion_model(xTrue, u) + Qsim @ np.random.randn(4, 1)
```

… implements …

![x_k](https://latex.codecogs.com/gif.latex?\mathbf{x}_k&space;=&space;\mathbf{F}&space;\mathbf{x}_{k-1}&space;&plus;&space;\mathbf{w}_k)

… while …

```python
z = observation_model(xTrue) + Rsim @ np.random.randn(2, 1)
```

… implements …

![z_k](https://latex.codecogs.com/gif.latex?\mathbf{z}_k&space;=&space;\mathbf{H&space;x}_k&space;&plus;&space;\mathbf{v}_k)

… while …

```python
xd = motion_model(xd, u)
```

… assumes lack of noise, resulting in massive drifts for dead-reckoning.

---

The reason this code was incorrect, yet produced convincing results is that the dead-reckoning was actually fed noisy inputs, while EKF/UKF worked with mostly clean measurements.