### PR TITLE
cvxpy link fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ See this paper for more details:
 
 - pandas
 
-- [cvxpy](http://www.cvxpy.org/en/latest/) 
+- [cvxpy](https://www.cvxpy.org/index.html) 
 
 # Documentation
 


### PR DESCRIPTION
While going through the documentation I noticed that the link the latest version of CVXPY was broken. 