### PR TITLE
Fix wrong rotation direction for DWA and Change resampling for the PF

### DIFF
--- a/Localization/particle_filter/particle_filter.py
+++ b/Localization/particle_filter/particle_filter.py
@@ -141,9 +141,8 @@ def re_sampling(px, pw):
     N_eff = 1.0 / (pw.dot(pw.T))[0, 0]  # Effective particle number
     if N_eff < NTh:
         w_cum = np.cumsum(pw)
-        base = np.cumsum(pw * 0.0 + 1 / NP) - 1 / NP
-        re_sample_id = base + np.random.rand(base.shape[0]) / NP
-
+        base = np.arange(0.0, 1.0, 1/NP)
+        re_sample_id = base + np.random.uniform(0, 1/NP)
         indexes = []
         ind = 0
         for ip in range(NP):

--- a/Localization/particle_filter/particle_filter.py
+++ b/Localization/particle_filter/particle_filter.py
@@ -128,8 +128,9 @@ def pf_localization(px, pw, z, u):
     xEst = px.dot(pw.T)
     PEst = calc_covariance(xEst, px, pw)
 
-    px, pw = re_sampling(px, pw)
-
+    N_eff = 1.0 / (pw.dot(pw.T))[0, 0]  # Effective particle number
+    if N_eff < NTh:
+        px, pw = re_sampling(px, pw)
     return xEst, PEst, px, pw
 
 
@@ -138,20 +139,18 @@ def re_sampling(px, pw):
     low variance re-sampling
     """
 
-    N_eff = 1.0 / (pw.dot(pw.T))[0, 0]  # Effective particle number
-    if N_eff < NTh:
-        w_cum = np.cumsum(pw)
-        base = np.arange(0.0, 1.0, 1/NP)
-        re_sample_id = base + np.random.uniform(0, 1/NP)
-        indexes = []
-        ind = 0
-        for ip in range(NP):
-            while re_sample_id[ip] > w_cum[ind]:
-                ind += 1
-            indexes.append(ind)
+    w_cum = np.cumsum(pw)
+    base = np.arange(0.0, 1.0, 1/NP)
+    re_sample_id = base + np.random.uniform(0, 1/NP)
+    indexes = []
+    ind = 0
+    for ip in range(NP):
+        while re_sample_id[ip] > w_cum[ind]:
+            ind += 1
+        indexes.append(ind)
 
-        px = px[:, indexes]
-        pw = np.zeros((1, NP)) + 1.0 / NP  # init weight
+    px = px[:, indexes]
+    pw = np.zeros((1, NP)) + 1.0 / NP  # init weight
 
     return px, pw
 

--- a/PathPlanning/DynamicWindowApproach/dynamic_window_approach.py
+++ b/PathPlanning/DynamicWindowApproach/dynamic_window_approach.py
@@ -172,7 +172,7 @@ def calc_obstacle_cost(trajectory, ob, config):
         rot = np.transpose(rot, [2, 0, 1])
         local_ob = ob[:, None] - trajectory[:, 0:2]
         local_ob = local_ob.reshape(-1, local_ob.shape[-1])
-        local_ob = np.array([local_ob @ -x for x in rot])
+        local_ob = np.array([local_ob @ x for x in rot])
         local_ob = local_ob.reshape(-1, local_ob.shape[-1])
         upper_check = local_ob[:, 0] <= config.robot_length / 2
         right_check = local_ob[:, 1] <= config.robot_width / 2


### PR DESCRIPTION
After adding the rectangle obstacle calculation, I've tested the algorithm more to try different settings
and I've seen that sometimes robot hits obstacles, specifically during turns. I've realized, [the yaw angle should be positive instead of negative while rotating the obstacles](https://github.com/AtsushiSakai/PythonRobotics/blob/66fe2f5ef62de5cc01b5ae85f6cb853048b61407/PathPlanning/DynamicWindowApproach/dynamic_window_approach.py#L175). After the change, the robot stops before hitting the obstacles.

**EDIT: About PF Change**: In the book, Probabilistic Robotics and [Introduction to Mobile Robotics Slides ](http://ais.informatik.uni-freiburg.de/teaching/ss19/robotics/slides/09-pf-mcl.pdf) the random variable for the resampling function is chosen between 0 to 1/N only one time but in the code, it is calculated N times. I've changed it so that it matches with the book. 

