### PR TITLE
EKF-SLAM: Fix jacobian of observation

### DIFF
--- a/SLAM/EKFSLAM/ekf_slam.ipynb
+++ b/SLAM/EKFSLAM/ekf_slam.ipynb
@@ -479,7 +479,7 @@
     "    \"\"\"\n",
     "    sq = math.sqrt(q)\n",
     "    G = np.array([[-sq * delta[0, 0], - sq * delta[1, 0], 0, sq * delta[0, 0], sq * delta[1, 0]],\n",
-    "                  [delta[1, 0], - delta[0, 0], - 1.0, - delta[1, 0], delta[0, 0]]])\n",
+    "                  [delta[1, 0], - delta[0, 0], - q, - delta[1, 0], delta[0, 0]]])\n",
     "\n",
     "    G = G / q\n",
     "    nLM = calc_n_LM(x)\n",

--- a/SLAM/EKFSLAM/ekf_slam.py
+++ b/SLAM/EKFSLAM/ekf_slam.py
@@ -177,7 +177,7 @@ def calc_innovation(lm, xEst, PEst, z, LMid):
 def jacob_h(q, delta, x, i):
     sq = math.sqrt(q)
     G = np.array([[-sq * delta[0, 0], - sq * delta[1, 0], 0, sq * delta[0, 0], sq * delta[1, 0]],
-                  [delta[1, 0], - delta[0, 0], - 1.0, - delta[1, 0], delta[0, 0]]])
+                  [delta[1, 0], - delta[0, 0], - q, - delta[1, 0], delta[0, 0]]])
 
     G = G / q
     nLM = calc_n_lm(x)


### PR DESCRIPTION
I believe the partial derivative of an observation with respect to the angle should be equal to `-1`, yet in the code it's currently `-1/q`.

Here is a source I could find on the topic: 
http://ais.informatik.uni-freiburg.de/teaching/ws12/mapping/pdf/slam04-ekf-slam.pdf, Slide 33
<img width="847" alt="jacobian_observation" src="https://user-images.githubusercontent.com/49170155/69834131-cd4c0000-1238-11ea-8108-a9372d384a15.png">

Would greatly appreciate it if someone would take a second look!