### PR TITLE
Fixed typo in planning method docstring

### DIFF
--- a/PathPlanning/AStar/a_star.py
+++ b/PathPlanning/AStar/a_star.py
@@ -51,7 +51,7 @@ class AStarPlanner:
             sx: start x position [m]
             sy: start y position [m]
             gx: goal x position [m]
-            gx: goal x position [m]
+            gy: goal y position [m]
 
         output:
             rx: x position list of the final path


### PR DESCRIPTION
There is a typo on line 54 in the planning method docstring.