### PR TITLE
Add CodeQL security scanning

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,6 @@
+name: "Extended CodeQL Config"
+
+# This file adds additional queries to the default configuration to make it equivalent to what LGTM checks. 
+queries:
+  - name: Security and quality queries
+    uses: security-and-quality

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,6 +1,6 @@
 name: "Extended CodeQL Config"
 
-# This file adds additional queries to the default configuration to make it equivalent to what LGTM checks. 
+# This file adds additional queries to the default configuration to make it equivalent to what LGTM checks.
 queries:
   - name: Security and quality queries
     uses: security-and-quality

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,52 @@
+name: "Code scanning - action"
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 19 * * 0'
+
+jobs:
+  CodeQL-Build:
+
+    # CodeQL runs on ubuntu-latest and windows-latest
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        # We must fetch at least the immediate parents so that if this is
+        # a pull request then we can checkout the head.
+        fetch-depth: 2
+
+    # If this run was triggered by a pull request event, then checkout
+    # the head of the pull request instead of the merge commit.
+    - run: git checkout HEAD^2
+      if: ${{ github.event_name == 'pull_request' }}
+      
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      # Override language selection by uncommenting this and choosing your languages
+      # with:
+      #   languages: go, javascript, csharp, python, cpp, java
+
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 https://git.io/JvXDl
+
+    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+    #    and modify them (or add more) to build your code if your project
+    #    uses a compiled language
+
+    #- run: |
+    #   make bootstrap
+    #   make release
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,6 +28,8 @@ jobs:
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1
+      with:
+        config-file: ./.github/codeql/codeql-config.yml
       # Override language selection by uncommenting this and choosing your languages
       # with:
       #   languages: go, javascript, csharp, python, cpp, java


### PR DESCRIPTION
Hi, I'm a PM on the GitHub security team. This repository is eligible to try the new [GitHub Advanced Security code scanning](https://help.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/about-code-scanning) beta.

Code scanning runs a static analysis tool called CodeQL which scans your code at build time to find any potential security issues. We've tuned the set of queries to be only the most severe, most precise issues. We'll show alerts in the security tab, and we'll show alerts for any net new vulnerabilities on pull requests as well. We've tried to make this super developer friendly, but we'd love your feedback as we work through the beta. 

If you're interested in trying it out, you can merge this pull request to set up the Actions workflow.