### PR TITLE
support no obstacle in RRT*

### DIFF
--- a/PathPlanning/RRTStar/rrt_star.py
+++ b/PathPlanning/RRTStar/rrt_star.py
@@ -87,7 +87,7 @@ class RRTStar(RRT):
         print("reached max iteration")
 
         last_index = self.search_best_goal_node()
-        if last_index:
+        if last_index is not None:
             return self.generate_final_course(last_index)
 
         return None

--- a/PathPlanning/RRTStar/rrt_star.py
+++ b/PathPlanning/RRTStar/rrt_star.py
@@ -81,7 +81,7 @@ class RRTStar(RRT):
 
             if (not search_until_max_iter) and new_node:  # check reaching the goal
                 last_index = self.search_best_goal_node()
-                if last_index:
+                if last_index is not None:
                     return self.generate_final_course(last_index)
 
         print("reached max iteration")

--- a/tests/test_rrt_star.py
+++ b/tests/test_rrt_star.py
@@ -25,11 +25,11 @@ class Test(TestCase):
 
         # Set Initial parameters
         rrt_star = m.RRTStar(start=[0, 0],
-                           goal=[6, 10],
-                           rand_area=[-2, 15],
-                           obstacle_list=obstacle_list)
+                             goal=[6, 10],
+                             rand_area=[-2, 15],
+                             obstacle_list=obstacle_list)
         path = rrt_star.planning(animation=False)
-        assert path != None
+        assert path is not None
 
 if __name__ == '__main__':  # pragma: no cover
     test = Test()

--- a/tests/test_rrt_star.py
+++ b/tests/test_rrt_star.py
@@ -20,7 +20,18 @@ class Test(TestCase):
         m.show_animation = False
         m.main()
 
+    def test_no_obstacle(self):
+        obstacle_list = []
+
+        # Set Initial parameters
+        rrt_star = m.RRTStar(start=[0, 0],
+                           goal=[6, 10],
+                           rand_area=[-2, 15],
+                           obstacle_list=obstacle_list)
+        path = rrt_star.planning(animation=False)
+        assert path != None
 
 if __name__ == '__main__':  # pragma: no cover
     test = Test()
     test.test1()
+    test.test_no_obstacle()


### PR DESCRIPTION
since `last_index` is 0 when there is no obstacle, the planning will return no path found. Checking for `last_index` being `None` will resolve this issue.