### PR TITLE
More intuitive way of plot_covariance_ellipse()

### DIFF
--- a/Localization/ensemble_kalman_filter/ensemble_kalman_filter.py
+++ b/Localization/ensemble_kalman_filter/ensemble_kalman_filter.py
@@ -167,7 +167,7 @@ def plot_covariance_ellipse(xEst, PEst):  # pragma: no cover
 
     x = [a * math.cos(it) for it in t]
     y = [b * math.sin(it) for it in t]
-    angle = math.atan2(eigvec[1, bigind], eigvec[0, bigind])
+    angle = math.atan2(eig_vec[1, big_ind], eig_vec[0, big_ind])
     rot = Rot.from_euler('z', angle).as_matrix()[0:2, 0:2]
     fx = np.stack([x, y]).T @ rot
 

--- a/Localization/ensemble_kalman_filter/ensemble_kalman_filter.py
+++ b/Localization/ensemble_kalman_filter/ensemble_kalman_filter.py
@@ -167,7 +167,7 @@ def plot_covariance_ellipse(xEst, PEst):  # pragma: no cover
 
     x = [a * math.cos(it) for it in t]
     y = [b * math.sin(it) for it in t]
-    angle = math.atan2(eig_vec[big_ind, 1], eig_vec[big_ind, 0])
+    angle = math.atan2(eigvec[1, bigind], eigvec[0, bigind])
     rot = Rot.from_euler('z', angle).as_matrix()[0:2, 0:2]
     fx = np.stack([x, y]).T @ rot
 

--- a/Localization/extended_kalman_filter/extended_kalman_filter.py
+++ b/Localization/extended_kalman_filter/extended_kalman_filter.py
@@ -147,9 +147,9 @@ def plot_covariance_ellipse(xEst, PEst):  # pragma: no cover
     b = math.sqrt(eigval[smallind])
     x = [a * math.cos(it) for it in t]
     y = [b * math.sin(it) for it in t]
-    angle = math.atan2(eigvec[bigind, 1], eigvec[bigind, 0])
-    rot = np.array([[math.cos(angle), math.sin(angle)],
-                    [-math.sin(angle), math.cos(angle)]])
+    angle = math.atan2(eigvec[1, bigind], eigvec[0, bigind])
+    rot = np.array([[math.cos(angle), -math.sin(angle)],
+                    [math.sin(angle), math.cos(angle)]])
     fx = rot @ (np.array([x, y]))
     px = np.array(fx[0, :] + xEst[0, 0]).flatten()
     py = np.array(fx[1, :] + xEst[1, 0]).flatten()

--- a/Localization/extended_kalman_filter/extended_kalman_filter.py
+++ b/Localization/extended_kalman_filter/extended_kalman_filter.py
@@ -10,6 +10,7 @@ import math
 
 import matplotlib.pyplot as plt
 import numpy as np
+from scipy.spatial.transform import Rotation as Rot
 
 # Covariance for EKF simulation
 Q = np.diag([
@@ -148,8 +149,7 @@ def plot_covariance_ellipse(xEst, PEst):  # pragma: no cover
     x = [a * math.cos(it) for it in t]
     y = [b * math.sin(it) for it in t]
     angle = math.atan2(eigvec[1, bigind], eigvec[0, bigind])
-    rot = np.array([[math.cos(angle), -math.sin(angle)],
-                    [math.sin(angle), math.cos(angle)]])
+    rot = Rot.from_euler('z', angle).as_matrix()[0:2, 0:2]
     fx = rot @ (np.array([x, y]))
     px = np.array(fx[0, :] + xEst[0, 0]).flatten()
     py = np.array(fx[1, :] + xEst[1, 0]).flatten()

--- a/Localization/particle_filter/particle_filter.py
+++ b/Localization/particle_filter/particle_filter.py
@@ -188,7 +188,7 @@ def plot_covariance_ellipse(x_est, p_est):  # pragma: no cover
 
     x = [a * math.cos(it) for it in t]
     y = [b * math.sin(it) for it in t]
-    angle = math.atan2(eigvec[1, bigind], eigvec[0, bigind])
+    angle = math.atan2(eig_vec[1, big_ind], eig_vec[0, big_ind])
     rot = Rot.from_euler('z', angle).as_matrix()[0:2, 0:2]
     fx = rot.dot(np.array([[x, y]]))
     px = np.array(fx[0, :] + x_est[0, 0]).flatten()

--- a/Localization/particle_filter/particle_filter.py
+++ b/Localization/particle_filter/particle_filter.py
@@ -188,7 +188,7 @@ def plot_covariance_ellipse(x_est, p_est):  # pragma: no cover
 
     x = [a * math.cos(it) for it in t]
     y = [b * math.sin(it) for it in t]
-    angle = math.atan2(eig_vec[big_ind, 1], eig_vec[big_ind, 0])
+    angle = math.atan2(eigvec[1, bigind], eigvec[0, bigind])
     rot = Rot.from_euler('z', angle).as_matrix()[0:2, 0:2]
     fx = rot.dot(np.array([[x, y]]))
     px = np.array(fx[0, :] + x_est[0, 0]).flatten()

--- a/Localization/unscented_kalman_filter/unscented_kalman_filter.py
+++ b/Localization/unscented_kalman_filter/unscented_kalman_filter.py
@@ -10,6 +10,7 @@ import math
 
 import matplotlib.pyplot as plt
 import numpy as np
+from scipy.spatial.transform import Rotation as Rot
 import scipy.linalg
 
 # Covariance for UKF simulation
@@ -181,8 +182,7 @@ def plot_covariance_ellipse(xEst, PEst):  # pragma: no cover
     x = [a * math.cos(it) for it in t]
     y = [b * math.sin(it) for it in t]
     angle = math.atan2(eigvec[1, bigind], eigvec[0, bigind])
-    rot = np.array([[math.cos(angle), -math.sin(angle)],
-                    [math.sin(angle), math.cos(angle)]])
+    rot = Rot.from_euler('z', angle).as_matrix()[0:2, 0:2]
     fx = rot @ np.array([x, y])
     px = np.array(fx[0, :] + xEst[0, 0]).flatten()
     py = np.array(fx[1, :] + xEst[1, 0]).flatten()

--- a/Localization/unscented_kalman_filter/unscented_kalman_filter.py
+++ b/Localization/unscented_kalman_filter/unscented_kalman_filter.py
@@ -180,9 +180,9 @@ def plot_covariance_ellipse(xEst, PEst):  # pragma: no cover
     b = math.sqrt(eigval[smallind])
     x = [a * math.cos(it) for it in t]
     y = [b * math.sin(it) for it in t]
-    angle = math.atan2(eigvec[bigind, 1], eigvec[bigind, 0])
-    rot = np.array([[math.cos(angle), math.sin(angle)],
-                    [-math.sin(angle), math.cos(angle)]])
+    angle = math.atan2(eigvec[1, bigind], eigvec[0, bigind])
+    rot = np.array([[math.cos(angle), -math.sin(angle)],
+                    [math.sin(angle), math.cos(angle)]])
     fx = rot @ np.array([x, y])
     px = np.array(fx[0, :] + xEst[0, 0]).flatten()
     py = np.array(fx[1, :] + xEst[1, 0]).flatten()


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! 
Please ensure that your PR satisfies the checklist before submitting:
- [] This project only accept codes for python 3.8 or higher.
- [] If you add a new algorithm sample code, please add a unit test file under `test` dir.
     This sample test code might help you : https://github.com/AtsushiSakai/PythonRobotics/blob/master/tests/test_a_star.py
- [] If you fix a bug of existing code please add a test function in the test code to show the issue was solved.
- [] Please fix all issues on CI (All CI should be green), before code review.

Note that this is my hobby project; I appreciate your
patience during the review process.

Again, thanks for contributing!
-->

## Reference issue
<!--Example: fix #392-->

## What does this implement/fix?
<!--Please explain your changes.-->

This change suggests a more intuitive way of `plot_covariance_ellipse()` in `extended_kalman_filter.py` and `unscented_kalman_filter.py`. (This change doesn't affect the result.)

In `plot_covariance_ellipse()`, `np.linalg.eig(Pxy)` returns `eigval` and `eigvec` like below. 

```
eigval = [ l1, l2 ]

eigvec = [
    [v1_x, v2_x],
    [v1_y, v2_y]
]
```

So, I think it would be more  plausible if the `angle` of the ellipse and the `rot` matrix are calculated by

```
angle = atan2(v1_y, v1_x)

rot = [
    [cos(angle), -sin(angle)],
    [sin(angle),  cos(angle)]
]
```

## Additional information
<!--Any additional information you think is important.-->

The result is the same between before and after.

### Before:

```
angle = math.atan2(eigvec[bigind, 1], eigvec[bigind, 0])

rot = np.array([[math.cos(angle), math.sin(angle)],
                [-math.sin(angle), math.cos(angle)]]))
```

&#8595;

### After:

```
angle_ = math.atan2(eigvec[1, bigind], eigvec[0, bigind])

rot_ = np.array([[math.cos(angle_), -math.sin(angle_)],
                [math.sin(angle_), math.cos(angle_)]]))
```

The reason why is because the eigenvectors v1 and v2 are orthogonal and the norm is 1.

Therefore, v2_x = -v1_y, 

```
eigvec[bigind, 0] = v1_x
                  = eigvec[0, bigind]

eigvec[bigind, 1] = v2_x
                  = -v1_y
                  = -eigvec[1, bigind]

angle = atan2(eigvec[bigind, 1], eigvec[bigind, 0])
      = atan2(v2_x, v1_x)
      = atan2(-v1_y, v1_x)
      = -atan2(v1_y, v1_x)
      = -atan2(eigvec[1, bigind], eigvec[0, bigind])
      = -angle_
```

So,

```
rot(angle) = rot_^T(angle)
           = rot_^T(-angle_)
           = rot_(angle_)
```