### PR TITLE
fixing sign in lane center calculation

### DIFF
--- a/PathPlanning/StateLatticePlanner/state_lattice_planner.py
+++ b/PathPlanning/StateLatticePlanner/state_lattice_planner.py
@@ -156,7 +156,7 @@ def calc_lane_states(l_center, l_heading, l_width, v_width, d, nxy):
     :param nxy: sampling number
     :return: state list
     """
-    xc = math.cos(l_heading) * d + math.sin(l_heading) * l_center
+    xc = math.cos(l_heading) * d - math.sin(l_heading) * l_center
     yc = math.sin(l_heading) * d + math.cos(l_heading) * l_center
 
     states = []
@@ -301,7 +301,7 @@ def lane_state_sampling_test1():
     k0 = 0.0
 
     l_center = 10.0
-    l_heading = np.deg2rad(90.0)
+    l_heading = np.deg2rad(0.0)
     l_width = 3.0
     v_width = 1.0
     d = 10

--- a/PathPlanning/StateLatticePlanner/state_lattice_planner.py
+++ b/PathPlanning/StateLatticePlanner/state_lattice_planner.py
@@ -309,6 +309,9 @@ def lane_state_sampling_test1():
     states = calc_lane_states(l_center, l_heading, l_width, v_width, d, nxy)
     result = generate_path(states, k0)
 
+    if show_animation:
+        plt.close("all")
+
     for table in result:
         xc, yc, yawc = motion_model.generate_trajectory(
             table[3], table[4], table[5], k0)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! 
Please ensure that your PR satisfies the checklist before submitting:
- [] This project only accept codes for python 3.8 or higher.
- [] If you add a new algorithm sample code, please add a unit test file under `test` dir.
     This sample test code might help you : https://github.com/AtsushiSakai/PythonRobotics/blob/master/tests/test_a_star.py
- [] If you fix a bug of existing code please add a test function in the test code to show the issue was solved.
- [] Please fix all issues on CI (All CI should be green), before code review.

Note that this is my hobby project; I appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: fix #392-->
fix #425 

#### What does this implement/fix?
<!--Please explain your changes.-->
Using proper rotation matrix in xc, yc calculation for lane sampling

#### Additional information
<!--Any additional information you think is important.-->
Please let me know if there's other stuff I'm supposed to change. Never contributed to an open repo before. 