### PR TITLE
fix ICP negative dError. Issue #446

### DIFF
--- a/SLAM/iterative_closest_point/iterative_closest_point.py
+++ b/SLAM/iterative_closest_point/iterative_closest_point.py
@@ -48,7 +48,7 @@ def icp_matching(previous_points, current_points):
         indexes, error = nearest_neighbor_association(previous_points, current_points)
         Rt, Tt = svd_motion_estimation(previous_points[:, indexes], current_points)
 
-        if dError < 0:  # if negative error prevent matrix H changing, exit loop
+        if dError < 0:  # prevent matrix H changing, exit loop
             print("Converge", preError, dError, count)
             break
 

--- a/SLAM/iterative_closest_point/iterative_closest_point.py
+++ b/SLAM/iterative_closest_point/iterative_closest_point.py
@@ -48,7 +48,7 @@ def icp_matching(previous_points, current_points):
         indexes, error = nearest_neighbor_association(previous_points, current_points)
         Rt, Tt = svd_motion_estimation(previous_points[:, indexes], current_points)
 
-        if dError < 0: # if negative error prevent matrix H changing, exit loop
+        if dError < 0:  # if negative error prevent matrix H changing, exit loop
             print("Converge", preError, dError, count)
             break
 

--- a/SLAM/iterative_closest_point/iterative_closest_point.py
+++ b/SLAM/iterative_closest_point/iterative_closest_point.py
@@ -37,8 +37,9 @@ def icp_matching(previous_points, current_points):
         if show_animation:  # pragma: no cover
             plt.cla()
             # for stopping simulation with the esc key.
-            plt.gcf().canvas.mpl_connect('key_release_event',
-                                         lambda event: [exit(0) if event.key == 'escape' else None])
+            plt.gcf().canvas.mpl_connect(
+                'key_release_event',
+                lambda event: [exit(0) if event.key == 'escape' else None])
             plt.plot(previous_points[0, :], previous_points[1, :], ".r")
             plt.plot(current_points[0, :], current_points[1, :], ".b")
             plt.plot(0.0, 0.0, "xr")
@@ -48,20 +49,21 @@ def icp_matching(previous_points, current_points):
         indexes, error = nearest_neighbor_association(previous_points, current_points)
         Rt, Tt = svd_motion_estimation(previous_points[:, indexes], current_points)
 
+        dError = preError - error
+        print("Residual:", error)
+
         if dError < 0:  # prevent matrix H changing, exit loop
-            print("Converge", preError, dError, count)
+            print("Not Converge...", preError, dError, count)
             break
+
+        preError = error
 
         # update current points
         current_points = (Rt @ current_points) + Tt[:, np.newaxis]
 
         H = update_homogeneous_matrix(H, Rt, Tt)
 
-        dError = abs(preError - error)
-        preError = error
-        print("Residual:", error)
-
-        if dError <= EPS and dError >= 0:
+        if dError <= EPS:
             print("Converge", error, dError, count)
             break
         elif MAX_ITER <= count:

--- a/SLAM/iterative_closest_point/iterative_closest_point.py
+++ b/SLAM/iterative_closest_point/iterative_closest_point.py
@@ -50,7 +50,7 @@ def icp_matching(previous_points, current_points):
         Rt, Tt = svd_motion_estimation(previous_points[:, indexes], current_points)
         # update current points
         current_points = (Rt @ current_points) + Tt[:, np.newaxis]
-        
+
         dError = preError - error
         print("Residual:", error)
 
@@ -59,7 +59,6 @@ def icp_matching(previous_points, current_points):
             break
 
         preError = error
-
         H = update_homogeneous_matrix(H, Rt, Tt)
 
         if dError <= EPS:

--- a/SLAM/iterative_closest_point/iterative_closest_point.py
+++ b/SLAM/iterative_closest_point/iterative_closest_point.py
@@ -27,8 +27,8 @@ def icp_matching(previous_points, current_points):
     """
     H = None  # homogeneous transformation matrix
 
-    dError = 1000.0
-    preError = 1000.0
+    dError = np.inf
+    preError = np.inf
     count = 0
 
     while dError >= EPS:
@@ -48,6 +48,10 @@ def icp_matching(previous_points, current_points):
         indexes, error = nearest_neighbor_association(previous_points, current_points)
         Rt, Tt = svd_motion_estimation(previous_points[:, indexes], current_points)
 
+        if dError < 0: # if negative error prevent matrix H changing, exit loop
+            print("Converge", preError, dError, count)
+            break
+
         # update current points
         current_points = (Rt @ current_points) + Tt[:, np.newaxis]
 
@@ -57,7 +61,7 @@ def icp_matching(previous_points, current_points):
         preError = error
         print("Residual:", error)
 
-        if dError <= EPS:
+        if dError <= EPS and dError >= 0:
             print("Converge", error, dError, count)
             break
         elif MAX_ITER <= count:

--- a/SLAM/iterative_closest_point/iterative_closest_point.py
+++ b/SLAM/iterative_closest_point/iterative_closest_point.py
@@ -48,7 +48,9 @@ def icp_matching(previous_points, current_points):
 
         indexes, error = nearest_neighbor_association(previous_points, current_points)
         Rt, Tt = svd_motion_estimation(previous_points[:, indexes], current_points)
-
+        # update current points
+        current_points = (Rt @ current_points) + Tt[:, np.newaxis]
+        
         dError = preError - error
         print("Residual:", error)
 
@@ -57,9 +59,6 @@ def icp_matching(previous_points, current_points):
             break
 
         preError = error
-
-        # update current points
-        current_points = (Rt @ current_points) + Tt[:, np.newaxis]
 
         H = update_homogeneous_matrix(H, Rt, Tt)
 

--- a/SLAM/iterative_closest_point/iterative_closest_point.py
+++ b/SLAM/iterative_closest_point/iterative_closest_point.py
@@ -38,7 +38,7 @@ def icp_matching(previous_points, current_points):
             plt.cla()
             # for stopping simulation with the esc key.
             plt.gcf().canvas.mpl_connect('key_release_event',
-                    lambda event: [exit(0) if event.key == 'escape' else None])
+                                         lambda event: [exit(0) if event.key == 'escape' else None])
             plt.plot(previous_points[0, :], previous_points[1, :], ".r")
             plt.plot(current_points[0, :], current_points[1, :], ".b")
             plt.plot(0.0, 0.0, "xr")


### PR DESCRIPTION
#### Reference issue
fix #446

#### What does this implement/fix?
Fixes case of negative ```dError``` in ICP algorithm.

#### Additional information
Implementation:
When ```dError``` is negative (error is rising) exits iteration loop with values of previous iterations with lower error. 
The first iteration is guaranteed by defining ```dError``` and ```preError``` as np.inf before the loop.
