### PR TITLE
Fix: cvxpy cannot be installed

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,9 +1,11 @@
 name: python_robotics
+channels:
+  - conda-forge
 dependencies:
-- python
-- pip
-- scipy
-- numpy
-- pandas
-- cvxpy
-- matplotlib
+  - python=3.9
+  - pip
+  - scipy
+  - numpy
+  - pandas
+  - cvxpy
+  - matplotlib


### PR DESCRIPTION
I ran into #342 where I cannot just create a new conda environment using the existing `environment.yml` file.

<!-- 
Thanks for contributing a pull request! 
Please ensure that your PR satisfies the checklist before submitting:
- [] This project only accept codes for python 3.9 or higher.
- [] If you add a new algorithm sample code, please add a unit test file under `test` dir.
     This sample test code might help you : https://github.com/AtsushiSakai/PythonRobotics/blob/master/tests/test_a_star.py
- [] If you fix a bug of existing code please add a test function in the test code to show the issue was solved.
- [] Please fix all issues on CI (All CI should be green), before code review.

Note that this is my hobby project; I appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
See #342.

#### What does this implement/fix?
1. I added a channel to the yml file so that conda knows where to look for packages like `cvxpy`.
2. Since [requirements](https://pythonrobotics.readthedocs.io/en/latest/getting_started.html#requirements) needs Python to be 3.9 and up. I specified it in the yml file as well.

#### Additional information
<!--Any additional information you think is important.-->
None.