### PR TITLE
Fix No module error in GridBasedSweepCPP and ClosedLoopRRTStart

### DIFF
--- a/PathPlanning/ClosedLoopRRTStar/__init__.py
+++ b/PathPlanning/ClosedLoopRRTStar/__init__.py
@@ -1,8 +1,0 @@
-import os
-import sys
-
-sys.path.append(os.path.dirname(os.path.abspath(__file__)))
-sys.path.append(os.path.dirname(
-    os.path.abspath(__file__)) + "/../ReedsSheppPath/")
-sys.path.append(os.path.dirname(
-    os.path.abspath(__file__)) + "/../RRTStarReedsShepp/")

--- a/PathPlanning/ClosedLoopRRTStar/closed_loop_rrt_star_car.py
+++ b/PathPlanning/ClosedLoopRRTStar/closed_loop_rrt_star_car.py
@@ -5,14 +5,25 @@ Path planning Sample Code with Closed loop RRT for car like robot.
 author: AtsushiSakai(@Atsushi_twi)
 
 """
+import os
+import sys
 
 import matplotlib.pyplot as plt
 import numpy as np
-import reeds_shepp_path_planning
-from rrt_star_reeds_shepp import RRTStarReedsShepp
 
 import pure_pursuit
 import unicycle_model
+
+sys.path.append(os.path.dirname(
+    os.path.abspath(__file__)) + "/../ReedsSheppPath/")
+sys.path.append(os.path.dirname(
+    os.path.abspath(__file__)) + "/../RRTStarReedsShepp/")
+
+try:
+    import reeds_shepp_path_planning
+    from rrt_star_reeds_shepp import RRTStarReedsShepp
+except ImportError:
+    raise
 
 show_animation = True
 

--- a/PathPlanning/ClosedLoopRRTStar/closed_loop_rrt_star_car.py
+++ b/PathPlanning/ClosedLoopRRTStar/closed_loop_rrt_star_car.py
@@ -11,6 +11,8 @@ import sys
 import matplotlib.pyplot as plt
 import numpy as np
 
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
 import pure_pursuit
 import unicycle_model
 

--- a/PathPlanning/GridBasedSweepCPP/__init__.py
+++ b/PathPlanning/GridBasedSweepCPP/__init__.py
@@ -1,7 +1,0 @@
-import os
-import sys
-
-GRID_MAP_LIB = os.path.dirname(os.path.abspath(__file__)) + \
-               "/../../Mapping/"
-
-sys.path.append(GRID_MAP_LIB)

--- a/PathPlanning/GridBasedSweepCPP/grid_based_sweep_coverage_path_planner.py
+++ b/PathPlanning/GridBasedSweepCPP/grid_based_sweep_coverage_path_planner.py
@@ -264,7 +264,7 @@ def planning(ox, oy, resolution,
 
     grid_map, x_inds_goal_y, goal_y = setup_grid_map(rox, roy, resolution,
                                                      sweeping_direction)
-    print(x_inds_goal_y, goal_y)
+
     sweep_searcher = SweepSearcher(moving_direction, sweeping_direction,
                                    x_inds_goal_y, goal_y)
 

--- a/PathPlanning/GridBasedSweepCPP/grid_based_sweep_coverage_path_planner.py
+++ b/PathPlanning/GridBasedSweepCPP/grid_based_sweep_coverage_path_planner.py
@@ -13,10 +13,10 @@ import numpy as np
 from scipy.spatial.transform import Rotation as Rot
 import matplotlib.pyplot as plt
 
-sys.path.append(os.path.dirname(os.path.abspath(__file__)) + \
-               "/../../Mapping/")
+sys.path.append(os.path.dirname(os.path.abspath(__file__)) +
+                "/../../Mapping/")
 
-try :
+try:
     from grid_map_lib.grid_map_lib import GridMap
 except ImportError:
     raise
@@ -258,13 +258,14 @@ def planning(ox, oy, resolution,
              ):
     sweep_vec, sweep_start_position = find_sweep_direction_and_start_position(
         ox, oy)
+    print("sweep_vec", sweep_vec, sweep_start_position)
 
     rox, roy = convert_grid_coordinate(ox, oy, sweep_vec,
                                        sweep_start_position)
 
     grid_map, x_inds_goal_y, goal_y = setup_grid_map(rox, roy, resolution,
                                                      sweeping_direction)
-
+    print(x_inds_goal_y, goal_y)
     sweep_searcher = SweepSearcher(moving_direction, sweeping_direction,
                                    x_inds_goal_y, goal_y)
 
@@ -310,7 +311,7 @@ def main():  # pragma: no cover
 
     ox = [0.0, 20.0, 50.0, 100.0, 130.0, 40.0, 0.0]
     oy = [0.0, -20.0, 0.0, 30.0, 60.0, 80.0, 0.0]
-    resolution = 5.0
+    resolution = 1.0
     planning_animation(ox, oy, resolution)
 
     ox = [0.0, 50.0, 50.0, 0.0, 0.0]

--- a/PathPlanning/GridBasedSweepCPP/grid_based_sweep_coverage_path_planner.py
+++ b/PathPlanning/GridBasedSweepCPP/grid_based_sweep_coverage_path_planner.py
@@ -5,12 +5,21 @@ author: Atsushi Sakai
 """
 
 import math
+import os
+import sys
 from enum import IntEnum
 
 import numpy as np
 from scipy.spatial.transform import Rotation as Rot
-from Mapping.grid_map_lib.grid_map_lib import GridMap
 import matplotlib.pyplot as plt
+
+sys.path.append(os.path.dirname(os.path.abspath(__file__)) + \
+               "/../../Mapping/")
+
+try :
+    from grid_map_lib.grid_map_lib import GridMap
+except ImportError:
+    raise
 
 do_animation = True
 

--- a/PathPlanning/GridBasedSweepCPP/grid_based_sweep_coverage_path_planner.py
+++ b/PathPlanning/GridBasedSweepCPP/grid_based_sweep_coverage_path_planner.py
@@ -258,7 +258,6 @@ def planning(ox, oy, resolution,
              ):
     sweep_vec, sweep_start_position = find_sweep_direction_and_start_position(
         ox, oy)
-    print("sweep_vec", sweep_vec, sweep_start_position)
 
     rox, roy = convert_grid_coordinate(ox, oy, sweep_vec,
                                        sweep_start_position)
@@ -311,7 +310,7 @@ def main():  # pragma: no cover
 
     ox = [0.0, 20.0, 50.0, 100.0, 130.0, 40.0, 0.0]
     oy = [0.0, -20.0, 0.0, 30.0, 60.0, 80.0, 0.0]
-    resolution = 1.0
+    resolution = 5.0
     planning_animation(ox, oy, resolution)
 
     ox = [0.0, 50.0, 50.0, 0.0, 0.0]


### PR DESCRIPTION
#### Reference issue
fix #515
<!--Example: fix #515 -->

#### What does this implement/fix?
changed import Module path.
all the other codes has sys.path.append code in the main python code except
GridBasedSweepCPP and ClosedLoopRRTStart has in __init__.py which makes "No module error"

#### Additional information
