### PR TITLE
Limit play area in RRT

### DIFF
--- a/PathPlanning/RRT/rrt.py
+++ b/PathPlanning/RRT/rrt.py
@@ -261,7 +261,7 @@ def main(gx=6.0, gy=10.0):
         goal=[gx, gy],
         rand_area=[-2, 15],
         obstacle_list=obstacleList,
-        #play_area=[0, 10, 0, 14]
+        # play_area=[0, 10, 0, 14]
         )
     path = rrt.planning(animation=show_animation)
 

--- a/PathPlanning/RRT/rrt.py
+++ b/PathPlanning/RRT/rrt.py
@@ -180,6 +180,10 @@ class RRT:
         for (ox, oy, size) in self.obstacle_list:
             self.plot_circle(ox, oy, size)
 
+        if self.play_area != None:
+            plt.plot([self.play_area.xmin, self.play_area.xmax, self.play_area.xmax, self.play_area.xmin, self.play_area.xmin],
+                     [self.play_area.ymin, self.play_area.ymin, self.play_area.ymax, self.play_area.ymax, self.play_area.ymin], "-k")
+
         plt.plot(self.start.x, self.start.y, "xr")
         plt.plot(self.end.x, self.end.y, "xr")
         plt.axis("equal")
@@ -251,7 +255,7 @@ def main(gx=6.0, gy=10.0):
         start=[0, 0],
         goal=[gx, gy],
         rand_area=[-2, 15],
-#        play_area=[0,10,0,15],
+#        play_area=[0,10,0,14],
         obstacle_list=obstacleList)
     path = rrt.planning(animation=show_animation)
 

--- a/PathPlanning/RRT/rrt.py
+++ b/PathPlanning/RRT/rrt.py
@@ -32,7 +32,6 @@ class RRT:
             self.path_y = []
             self.parent = None
 
-
     class AreaBounds:
 
         def __init__(self, area):
@@ -68,7 +67,7 @@ class RRT:
         self.min_rand = rand_area[0]
         self.max_rand = rand_area[1]
         if play_area is not None:
-            self.play_area=self.AreaBounds(play_area)
+            self.play_area = self.AreaBounds(play_area)
         else:
             self.play_area = None
         self.expand_dis = expand_dis
@@ -93,7 +92,7 @@ class RRT:
 
             new_node = self.steer(nearest_node, rnd_node, self.expand_dis)
 
-            if self.check_if_outside_play_area(new_node,self.play_area) and \
+            if self.check_if_outside_play_area(new_node, self.play_area) and \
                self.check_collision(new_node, self.obstacle_list):
                 self.node_list.append(new_node)
 
@@ -182,8 +181,13 @@ class RRT:
             self.plot_circle(ox, oy, size)
 
         if self.play_area is not None:
-            plt.plot([self.play_area.xmin, self.play_area.xmax, self.play_area.xmax, self.play_area.xmin, self.play_area.xmin],
-                     [self.play_area.ymin, self.play_area.ymin, self.play_area.ymax, self.play_area.ymax, self.play_area.ymin], "-k")
+            plt.plot([self.play_area.xmin, self.play_area.xmax,
+                      self.play_area.xmax, self.play_area.xmin,
+                      self.play_area.xmin],
+                     [self.play_area.ymin, self.play_area.ymin,
+                      self.play_area.ymax, self.play_area.ymax,
+                      self.play_area.ymin],
+                      "-k")
 
         plt.plot(self.start.x, self.start.y, "xr")
         plt.plot(self.end.x, self.end.y, "xr")
@@ -209,16 +213,16 @@ class RRT:
         return minind
 
     @staticmethod
-    def check_if_outside_play_area(node,play_area):
+    def check_if_outside_play_area(node, play_area):
 
         if play_area is None:
-            return True # no play_area was defined, every pos should be ok
+            return True  # no play_area was defined, every pos should be ok
 
         if node.x < play_area.xmin or node.x > play_area.xmax or \
            node.y < play_area.ymin or node.y > play_area.ymax:
             return False  # outside - bad
         else:
-            return True # inside - ok
+            return True  # inside - ok
 
     @staticmethod
     def check_collision(node, obstacleList):
@@ -257,7 +261,7 @@ def main(gx=6.0, gy=10.0):
         goal=[gx, gy],
         rand_area=[-2, 15],
         obstacle_list=obstacleList,
-#        play_area=[0,10,0,14]
+        #play_area=[0, 10, 0, 14]
         )
     path = rrt.planning(animation=show_animation)
 

--- a/PathPlanning/RRT/rrt.py
+++ b/PathPlanning/RRT/rrt.py
@@ -47,11 +47,12 @@ class RRT:
                  goal,
                  obstacle_list,
                  rand_area,
-                 play_area=None,
                  expand_dis=3.0,
                  path_resolution=0.5,
                  goal_sample_rate=5,
-                 max_iter=500):
+                 max_iter=500,
+                 play_area=None
+                 ):
         """
         Setting Parameter
 
@@ -255,8 +256,9 @@ def main(gx=6.0, gy=10.0):
         start=[0, 0],
         goal=[gx, gy],
         rand_area=[-2, 15],
-#        play_area=[0,10,0,14],
-        obstacle_list=obstacleList)
+        obstacle_list=obstacleList,
+#        play_area=[0,10,0,14]
+        )
     path = rrt.planning(animation=show_animation)
 
     if path is None:

--- a/PathPlanning/RRT/rrt.py
+++ b/PathPlanning/RRT/rrt.py
@@ -36,10 +36,10 @@ class RRT:
     class AreaBounds:
 
         def __init__(self, area):
-            self.xmin = float(area[0]);
-            self.xmax = float(area[1]);
-            self.ymin = float(area[2]);
-            self.ymax = float(area[3]);
+            self.xmin = float(area[0])
+            self.xmax = float(area[1])
+            self.ymin = float(area[2])
+            self.ymax = float(area[3])
 
 
     def __init__(self,
@@ -180,7 +180,7 @@ class RRT:
         for (ox, oy, size) in self.obstacle_list:
             self.plot_circle(ox, oy, size)
 
-        if self.play_area != None:
+        if self.play_area is not None:
             plt.plot([self.play_area.xmin, self.play_area.xmax, self.play_area.xmax, self.play_area.xmin, self.play_area.xmin],
                      [self.play_area.ymin, self.play_area.ymin, self.play_area.ymax, self.play_area.ymax, self.play_area.ymin], "-k")
 

--- a/PathPlanning/RRT/rrt.py
+++ b/PathPlanning/RRT/rrt.py
@@ -187,7 +187,7 @@ class RRT:
                      [self.play_area.ymin, self.play_area.ymin,
                       self.play_area.ymax, self.play_area.ymax,
                       self.play_area.ymin],
-                      "-k")
+                     "-k")
 
         plt.plot(self.start.x, self.start.y, "xr")
         plt.plot(self.end.x, self.end.y, "xr")


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! 
Please ensure that your PR satisfies the checklist before submitting:
- [] This project only accept codes for python 3.9 or higher.
- [] If you add a new algorithm sample code, please add a unit test file under `test` dir.
     This sample test code might help you : https://github.com/AtsushiSakai/PythonRobotics/blob/master/tests/test_a_star.py
- [] If you fix a bug of existing code please add a test function in the test code to show the issue was solved.
- [] Please fix all issues on CI (All CI should be green), before code review.

Note that this is my hobby project; I appreciate your
patience during the review process.

Again, thanks for contributing!
-->

Thanks for creating PythonRobotics!
Just a tiny addition...

#### What does this implement/fix?
Limits the available play area (add walls) in the RRT sample.
