### PR TITLE
InvertedPendulumMPCControl: fixed deprecated waring about using * for…

### DIFF
--- a/Control/InvertedPendulumMPCControl/inverted_pendulum_mpc_control.py
+++ b/Control/InvertedPendulumMPCControl/inverted_pendulum_mpc_control.py
@@ -77,7 +77,7 @@ def mpc_control(x0):
     for t in range(T):
         cost += cvxpy.quad_form(x[:, t + 1], Q)
         cost += cvxpy.quad_form(u[:, t], R)
-        constr += [x[:, t + 1] == A * x[:, t] + B * u[:, t]]
+        constr += [x[:, t + 1] == A @ x[:, t] + B @ u[:, t]]
 
     constr += [x[:, 0] == x0[:, 0]]
     prob = cvxpy.Problem(cvxpy.Minimize(cost), constr)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! 
Please check this document before submitting:
- [How to contribute](https://pythonrobotics.readthedocs.io/en/latest/how_to_contribute.html#adding-a-new-algorithm-example)

Note that this is my hobby project; I appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: fix #392-->

#### What does this implement/fix?
<!--Please explain your changes.-->
Improve inverted_pendulum_mpc_control.py:
- Fix cvxpy warning about deprecated matrix multiplication syntax

```
This use of ``*`` has resulted in matrix multiplication.
Using ``*`` for matrix multiplication has been deprecated since CVXPY 1.1.
    Use ``*`` for matrix-scalar and vector-scalar multiplication.
    Use ``@`` for matrix-matrix and matrix-vector multiplication.
    Use ``multiply`` for elementwise multiplication.
```

#### Additional information
<!--Any additional information you think is important.-->

#### CheckList
-[] Did you add an unittest for your new example or defect fix?
-[] Did you add documents for your new example?
-[] All CIs are green? (You can check it after submitting)
