### PR TITLE
Fix a broken gif link in the "Lidar to grid map"

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ This is a 2D ray casting grid mapping example.
 
 This example shows how to convert a 2D range measurement to a grid map.
 
-![2](Mapping/lidar_to_grid_map/animation.gif)
+![2](https://github.com/AtsushiSakai/PythonRoboticsGifs/raw/master/Mapping/lidar_to_grid_map/animation.gif)
 
 ## k-means object clustering
 


### PR DESCRIPTION
The gif link is broken now. I think this is the right URL.

<!-- 
Thanks for contributing a pull request! 
Please check this document before submitting:
- [How to contribute](https://pythonrobotics.readthedocs.io/en/latest/how_to_contribute.html#adding-a-new-algorithm-example)

Note that this is my hobby project; I appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: fix #392-->
no
#### What does this implement/fix?
<!--Please explain your changes.-->

doc only.

#### Additional information
<!--Any additional information you think is important.-->

#### CheckList
-[] Did you add an unittest for your new example or defect fix?
-[] Did you add documents for your new example?
-[] All CIs are green? (You can check it after submitting)
