### PR TITLE
Fix typo: correction for missing 'delta t' in EKF documentation

### DIFF
--- a/docs/modules/localization/extended_kalman_filter_localization_files/extended_kalman_filter_localization.rst
+++ b/docs/modules/localization/extended_kalman_filter_localization_files/extended_kalman_filter_localization.rst
@@ -89,7 +89,7 @@ This is implemented at
 
 The motion function is that
 
-:math:`\begin{equation*} \begin{bmatrix} x' \\ y' \\ w' \\ v' \end{bmatrix} = f(\textbf{x}, \textbf{u}) = \begin{bmatrix} x + v\cos(\phi)\Delta t \\ y + v\sin(\phi) \\ \phi + \omega \Delta t \\ v \end{bmatrix} \end{equation*}`
+:math:`\begin{equation*} \begin{bmatrix} x' \\ y' \\ w' \\ v' \end{bmatrix} = f(\textbf{x}, \textbf{u}) = \begin{bmatrix} x + v\cos(\phi)\Delta t \\ y + v\sin(\phi)\Delta t \\ \phi + \omega \Delta t \\ v \end{bmatrix} \end{equation*}`
 
 Its Jacobian matrix is
 


### PR DESCRIPTION
Reference issue
typo

What does this implement/fix?
Update motion function in localization/EKF documentation. Add missing delta t.