### PR TITLE
Add optional robot radius to RRT/RRTStar path planners

### DIFF
--- a/PathPlanning/ClosedLoopRRTStar/closed_loop_rrt_star_car.py
+++ b/PathPlanning/ClosedLoopRRTStar/closed_loop_rrt_star_car.py
@@ -129,7 +129,7 @@ class ClosedLoopRRTStar(RRTStarReedsShepp):
             print("path is too long")
             find_goal = False
 
-        tmp_node = self.Node(0,0,0)
+        tmp_node = self.Node(0, 0, 0)
         tmp_node.path_x = x
         tmp_node.path_y = y
         if not self.check_collision(

--- a/PathPlanning/ClosedLoopRRTStar/closed_loop_rrt_star_car.py
+++ b/PathPlanning/ClosedLoopRRTStar/closed_loop_rrt_star_car.py
@@ -129,7 +129,8 @@ class ClosedLoopRRTStar(RRTStarReedsShepp):
             print("path is too long")
             find_goal = False
 
-        if not self.collision_check_with_xy(x, y, self.obstacle_list, self.robot_radius):
+        if not self.collision_check_with_xy(
+                x, y, self.obstacle_list, self.robot_radius):
             print("This path is collision")
             find_goal = False
 

--- a/PathPlanning/ClosedLoopRRTStar/closed_loop_rrt_star_car.py
+++ b/PathPlanning/ClosedLoopRRTStar/closed_loop_rrt_star_car.py
@@ -37,11 +37,13 @@ class ClosedLoopRRTStar(RRTStarReedsShepp):
 
     def __init__(self, start, goal, obstacle_list, rand_area,
                  max_iter=200,
-                 connect_circle_dist=50.0
+                 connect_circle_dist=50.0,
+                 robot_radius=0.0
                  ):
         super().__init__(start, goal, obstacle_list, rand_area,
                          max_iter=max_iter,
                          connect_circle_dist=connect_circle_dist,
+                         robot_radius=robot_radius
                          )
 
         self.target_speed = 10.0 / 3.6
@@ -127,7 +129,7 @@ class ClosedLoopRRTStar(RRTStarReedsShepp):
             print("path is too long")
             find_goal = False
 
-        if not self.collision_check_with_xy(x, y, self.obstacle_list):
+        if not self.collision_check_with_xy(x, y, self.obstacle_list, self.robot_radius):
             print("This path is collision")
             find_goal = False
 
@@ -152,14 +154,14 @@ class ClosedLoopRRTStar(RRTStarReedsShepp):
         return fgoalinds
 
     @staticmethod
-    def collision_check_with_xy(x, y, obstacle_list):
+    def collision_check_with_xy(x, y, obstacle_list, robot_radius):
 
         for (ox, oy, size) in obstacle_list:
             for (ix, iy) in zip(x, y):
                 dx = ox - ix
                 dy = oy - iy
                 d = dx * dx + dy * dy
-                if d <= size ** 2:
+                if d <= (size + robot_radius) ** 2:
                     return False  # collision
 
         return True  # safe

--- a/PathPlanning/ClosedLoopRRTStar/closed_loop_rrt_star_car.py
+++ b/PathPlanning/ClosedLoopRRTStar/closed_loop_rrt_star_car.py
@@ -129,8 +129,11 @@ class ClosedLoopRRTStar(RRTStarReedsShepp):
             print("path is too long")
             find_goal = False
 
-        if not self.collision_check_with_xy(
-                x, y, self.obstacle_list, self.robot_radius):
+        tmp_node = self.Node(0,0,0)
+        tmp_node.path_x = x
+        tmp_node.path_y = y
+        if not self.check_collision(
+                tmp_node, self.obstacle_list, self.robot_radius):
             print("This path is collision")
             find_goal = False
 
@@ -153,19 +156,6 @@ class ClosedLoopRRTStar(RRTStarReedsShepp):
         print(len(fgoalinds))
 
         return fgoalinds
-
-    @staticmethod
-    def collision_check_with_xy(x, y, obstacle_list, robot_radius):
-
-        for (ox, oy, size) in obstacle_list:
-            for (ix, iy) in zip(x, y):
-                dx = ox - ix
-                dy = oy - iy
-                d = dx * dx + dy * dy
-                if d <= (size + robot_radius) ** 2:
-                    return False  # collision
-
-        return True  # safe
 
 
 def main(gx=6.0, gy=7.0, gyaw=np.deg2rad(90.0), max_iter=100):

--- a/PathPlanning/ClosedLoopRRTStar/closed_loop_rrt_star_car.py
+++ b/PathPlanning/ClosedLoopRRTStar/closed_loop_rrt_star_car.py
@@ -129,7 +129,7 @@ class ClosedLoopRRTStar(RRTStarReedsShepp):
             print("path is too long")
             find_goal = False
 
-        tmp_node = self.Node(0, 0, 0)
+        tmp_node = self.Node(x, y, 0)
         tmp_node.path_x = x
         tmp_node.path_y = y
         if not self.check_collision(

--- a/PathPlanning/LQRRRTStar/lqr_rrt_star.py
+++ b/PathPlanning/LQRRRTStar/lqr_rrt_star.py
@@ -45,6 +45,7 @@ class LQRRRTStar(RRTStar):
         goal:Goal Position [x,y]
         obstacleList:obstacle Positions [[x,y,size],...]
         randArea:Random Sampling Area [min,max]
+        robot_radius: robot body modeled as circle with given radius
 
         """
         self.start = self.Node(start[0], start[1])

--- a/PathPlanning/LQRRRTStar/lqr_rrt_star.py
+++ b/PathPlanning/LQRRRTStar/lqr_rrt_star.py
@@ -77,7 +77,8 @@ class LQRRRTStar(RRTStar):
             nearest_ind = self.get_nearest_node_index(self.node_list, rnd)
             new_node = self.steer(self.node_list[nearest_ind], rnd)
 
-            if self.check_collision(new_node, self.obstacle_list, self.robot_radius):
+            if self.check_collision(
+                    new_node, self.obstacle_list, self.robot_radius):
                 near_indexes = self.find_near_nodes(new_node)
                 new_node = self.choose_parent(new_node, near_indexes)
                 if new_node:

--- a/PathPlanning/LQRRRTStar/lqr_rrt_star.py
+++ b/PathPlanning/LQRRRTStar/lqr_rrt_star.py
@@ -35,7 +35,8 @@ class LQRRRTStar(RRTStar):
                  goal_sample_rate=10,
                  max_iter=200,
                  connect_circle_dist=50.0,
-                 step_size=0.2
+                 step_size=0.2,
+                 robot_radius=0.0,
                  ):
         """
         Setting Parameter
@@ -58,6 +59,7 @@ class LQRRRTStar(RRTStar):
         self.curvature = 1.0
         self.goal_xy_th = 0.5
         self.step_size = step_size
+        self.robot_radius = robot_radius
 
         self.lqr_planner = LQRPlanner()
 
@@ -75,7 +77,7 @@ class LQRRRTStar(RRTStar):
             nearest_ind = self.get_nearest_node_index(self.node_list, rnd)
             new_node = self.steer(self.node_list[nearest_ind], rnd)
 
-            if self.check_collision(new_node, self.obstacle_list):
+            if self.check_collision(new_node, self.obstacle_list, self.robot_radius):
                 near_indexes = self.find_near_nodes(new_node)
                 new_node = self.choose_parent(new_node, near_indexes)
                 if new_node:

--- a/PathPlanning/RRT/rrt.py
+++ b/PathPlanning/RRT/rrt.py
@@ -50,7 +50,8 @@ class RRT:
                  path_resolution=0.5,
                  goal_sample_rate=5,
                  max_iter=500,
-                 play_area=None
+                 play_area=None,
+                 robot_radius=0.0,
                  ):
         """
         Setting Parameter
@@ -60,6 +61,7 @@ class RRT:
         obstacleList:obstacle Positions [[x,y,size],...]
         randArea:Random Sampling Area [min,max]
         play_area:stay inside this area [xmin,xmax,ymin,ymax]
+        robot_radius: robot body modeled as circle with given radius
 
         """
         self.start = self.Node(start[0], start[1])
@@ -76,6 +78,7 @@ class RRT:
         self.max_iter = max_iter
         self.obstacle_list = obstacle_list
         self.node_list = []
+        self.robot_radius = robot_radius
 
     def planning(self, animation=True):
         """
@@ -93,7 +96,7 @@ class RRT:
             new_node = self.steer(nearest_node, rnd_node, self.expand_dis)
 
             if self.check_if_outside_play_area(new_node, self.play_area) and \
-               self.check_collision(new_node, self.obstacle_list):
+               self.check_collision(new_node, self.obstacle_list, self.robot_radius):
                 self.node_list.append(new_node)
 
             if animation and i % 5 == 0:
@@ -103,7 +106,7 @@ class RRT:
                                       self.node_list[-1].y) <= self.expand_dis:
                 final_node = self.steer(self.node_list[-1], self.end,
                                         self.expand_dis)
-                if self.check_collision(final_node, self.obstacle_list):
+                if self.check_collision(final_node, self.obstacle_list, self.robot_radius):
                     return self.generate_final_course(len(self.node_list) - 1)
 
             if animation and i % 5:
@@ -173,6 +176,8 @@ class RRT:
             lambda event: [exit(0) if event.key == 'escape' else None])
         if rnd is not None:
             plt.plot(rnd.x, rnd.y, "^k")
+            if self.robot_radius > 0.0:
+                self.plot_circle(rnd.x, rnd.y, self.robot_radius, '-r')
         for node in self.node_list:
             if node.parent:
                 plt.plot(node.path_x, node.path_y, "-g")
@@ -225,7 +230,7 @@ class RRT:
             return True  # inside - ok
 
     @staticmethod
-    def check_collision(node, obstacleList):
+    def check_collision(node, obstacleList, robot_radius):
 
         if node is None:
             return False
@@ -235,7 +240,7 @@ class RRT:
             dy_list = [oy - y for y in node.path_y]
             d_list = [dx * dx + dy * dy for (dx, dy) in zip(dx_list, dy_list)]
 
-            if min(d_list) <= size**2:
+            if min(d_list) <= (size+robot_radius)**2:
                 return False  # collision
 
         return True  # safe
@@ -262,6 +267,7 @@ def main(gx=6.0, gy=10.0):
         rand_area=[-2, 15],
         obstacle_list=obstacleList,
         # play_area=[0, 10, 0, 14]
+        robot_radius=0.8
         )
     path = rrt.planning(animation=show_animation)
 

--- a/PathPlanning/RRT/rrt.py
+++ b/PathPlanning/RRT/rrt.py
@@ -96,7 +96,8 @@ class RRT:
             new_node = self.steer(nearest_node, rnd_node, self.expand_dis)
 
             if self.check_if_outside_play_area(new_node, self.play_area) and \
-               self.check_collision(new_node, self.obstacle_list, self.robot_radius):
+               self.check_collision(
+                   new_node, self.obstacle_list, self.robot_radius):
                 self.node_list.append(new_node)
 
             if animation and i % 5 == 0:
@@ -106,7 +107,8 @@ class RRT:
                                       self.node_list[-1].y) <= self.expand_dis:
                 final_node = self.steer(self.node_list[-1], self.end,
                                         self.expand_dis)
-                if self.check_collision(final_node, self.obstacle_list, self.robot_radius):
+                if self.check_collision(
+                        final_node, self.obstacle_list, self.robot_radius):
                     return self.generate_final_course(len(self.node_list) - 1)
 
             if animation and i % 5:

--- a/PathPlanning/RRT/rrt_with_sobol_sampler.py
+++ b/PathPlanning/RRT/rrt_with_sobol_sampler.py
@@ -102,7 +102,8 @@ class RRTSobol:
 
             new_node = self.steer(nearest_node, rnd_node, self.expand_dis)
 
-            if self.check_collision(new_node, self.obstacle_list, self.robot_radius):
+            if self.check_collision(
+                    new_node, self.obstacle_list, self.robot_radius):
                 self.node_list.append(new_node)
 
             if animation and i % 5 == 0:
@@ -112,7 +113,8 @@ class RRTSobol:
                                       self.node_list[-1].y) <= self.expand_dis:
                 final_node = self.steer(self.node_list[-1], self.end,
                                         self.expand_dis)
-                if self.check_collision(final_node, self.obstacle_list, self.robot_radius):
+                if self.check_collision(
+                        final_node, self.obstacle_list, self.robot_radius):
                     return self.generate_final_course(len(self.node_list) - 1)
 
             if animation and i % 5:

--- a/PathPlanning/RRT/rrt_with_sobol_sampler.py
+++ b/PathPlanning/RRT/rrt_with_sobol_sampler.py
@@ -62,7 +62,8 @@ class RRTSobol:
                  expand_dis=3.0,
                  path_resolution=0.5,
                  goal_sample_rate=5,
-                 max_iter=500):
+                 max_iter=500,
+                 robot_radius=0.0):
         """
         Setting Parameter
 
@@ -70,6 +71,7 @@ class RRTSobol:
         goal:Goal Position [x,y]
         obstacle_list:obstacle Positions [[x,y,size],...]
         randArea:Random Sampling Area [min,max]
+        robot_radius: robot body modeled as circle with given radius
 
         """
         self.start = self.Node(start[0], start[1])
@@ -83,6 +85,7 @@ class RRTSobol:
         self.obstacle_list = obstacle_list
         self.node_list = []
         self.sobol_inter_ = 0
+        self.robot_radius = robot_radius
 
     def planning(self, animation=True):
         """
@@ -99,7 +102,7 @@ class RRTSobol:
 
             new_node = self.steer(nearest_node, rnd_node, self.expand_dis)
 
-            if self.check_collision(new_node, self.obstacle_list):
+            if self.check_collision(new_node, self.obstacle_list, self.robot_radius):
                 self.node_list.append(new_node)
 
             if animation and i % 5 == 0:
@@ -109,7 +112,7 @@ class RRTSobol:
                                       self.node_list[-1].y) <= self.expand_dis:
                 final_node = self.steer(self.node_list[-1], self.end,
                                         self.expand_dis)
-                if self.check_collision(final_node, self.obstacle_list):
+                if self.check_collision(final_node, self.obstacle_list, self.robot_radius):
                     return self.generate_final_course(len(self.node_list) - 1)
 
             if animation and i % 5:
@@ -183,6 +186,8 @@ class RRTSobol:
             lambda event: [sys.exit(0) if event.key == 'escape' else None])
         if rnd is not None:
             plt.plot(rnd.x, rnd.y, "^k")
+            if self.robot_radius >= 0.0:
+                self.plot_circle(rnd.x, rnd.y, self.robot_radius, '-r')
         for node in self.node_list:
             if node.parent:
                 plt.plot(node.path_x, node.path_y, "-g")
@@ -214,7 +219,7 @@ class RRTSobol:
         return minind
 
     @staticmethod
-    def check_collision(node, obstacle_list):
+    def check_collision(node, obstacle_list, robot_radius):
 
         if node is None:
             return False
@@ -224,7 +229,7 @@ class RRTSobol:
             dy_list = [oy - y for y in node.path_y]
             d_list = [dx * dx + dy * dy for (dx, dy) in zip(dx_list, dy_list)]
 
-            if min(d_list) <= size**2:
+            if min(d_list) <= (size+robot_radius)**2:
                 return False  # collision
 
         return True  # safe
@@ -249,7 +254,8 @@ def main(gx=6.0, gy=10.0):
         start=[0, 0],
         goal=[gx, gy],
         rand_area=[-2, 15],
-        obstacle_list=obstacle_list)
+        obstacle_list=obstacle_list,
+        robot_radius=0.8)
     path = rrt.planning(animation=show_animation)
 
     if path is None:

--- a/PathPlanning/RRTDubins/rrt_dubins.py
+++ b/PathPlanning/RRTDubins/rrt_dubins.py
@@ -46,6 +46,7 @@ class RRTDubins(RRT):
     def __init__(self, start, goal, obstacle_list, rand_area,
                  goal_sample_rate=10,
                  max_iter=200,
+                 robot_radius=0.0
                  ):
         """
         Setting Parameter
@@ -67,6 +68,7 @@ class RRTDubins(RRT):
         self.curvature = 1.0  # for dubins path
         self.goal_yaw_th = np.deg2rad(1.0)
         self.goal_xy_th = 0.5
+        self.robot_radius = robot_radius
 
     def planning(self, animation=True, search_until_max_iter=True):
         """
@@ -82,7 +84,7 @@ class RRTDubins(RRT):
             nearest_ind = self.get_nearest_node_index(self.node_list, rnd)
             new_node = self.steer(self.node_list[nearest_ind], rnd)
 
-            if self.check_collision(new_node, self.obstacle_list):
+            if self.check_collision(new_node, self.obstacle_list, self.robot_radius):
                 self.node_list.append(new_node)
 
             if animation and i % 5 == 0:

--- a/PathPlanning/RRTDubins/rrt_dubins.py
+++ b/PathPlanning/RRTDubins/rrt_dubins.py
@@ -55,6 +55,7 @@ class RRTDubins(RRT):
         goal:Goal Position [x,y]
         obstacleList:obstacle Positions [[x,y,size],...]
         randArea:Random Sampling Area [min,max]
+        robot_radius: robot body modeled as circle with given radius
 
         """
         self.start = self.Node(start[0], start[1], start[2])

--- a/PathPlanning/RRTDubins/rrt_dubins.py
+++ b/PathPlanning/RRTDubins/rrt_dubins.py
@@ -84,7 +84,8 @@ class RRTDubins(RRT):
             nearest_ind = self.get_nearest_node_index(self.node_list, rnd)
             new_node = self.steer(self.node_list[nearest_ind], rnd)
 
-            if self.check_collision(new_node, self.obstacle_list, self.robot_radius):
+            if self.check_collision(
+                    new_node, self.obstacle_list, self.robot_radius):
                 self.node_list.append(new_node)
 
             if animation and i % 5 == 0:

--- a/PathPlanning/RRTStar/rrt_star.py
+++ b/PathPlanning/RRTStar/rrt_star.py
@@ -54,7 +54,8 @@ class RRTStar(RRT):
 
         """
         super().__init__(start, goal, obstacle_list, rand_area, expand_dis,
-                         path_resolution, goal_sample_rate, max_iter, robot_radius=robot_radius)
+                         path_resolution, goal_sample_rate, max_iter,
+                         robot_radius=robot_radius)
         self.connect_circle_dist = connect_circle_dist
         self.goal_node = self.Node(goal[0], goal[1])
         self.search_until_max_iter = search_until_max_iter
@@ -78,7 +79,8 @@ class RRTStar(RRT):
                 math.hypot(new_node.x-near_node.x,
                            new_node.y-near_node.y)
 
-            if self.check_collision(new_node, self.obstacle_list, self.robot_radius):
+            if self.check_collision(
+                    new_node, self.obstacle_list, self.robot_radius):
                 near_inds = self.find_near_nodes(new_node)
                 node_with_updated_parent = self.choose_parent(
                     new_node, near_inds)
@@ -129,7 +131,8 @@ class RRTStar(RRT):
         for i in near_inds:
             near_node = self.node_list[i]
             t_node = self.steer(near_node, new_node)
-            if t_node and self.check_collision(t_node, self.obstacle_list, self.robot_radius):
+            if t_node and self.check_collision(
+                    t_node, self.obstacle_list, self.robot_radius):
                 costs.append(self.calc_new_cost(near_node, new_node))
             else:
                 costs.append(float("inf"))  # the cost of collision node
@@ -157,7 +160,8 @@ class RRTStar(RRT):
         safe_goal_inds = []
         for goal_ind in goal_inds:
             t_node = self.steer(self.node_list[goal_ind], self.goal_node)
-            if self.check_collision(t_node, self.obstacle_list, self.robot_radius):
+            if self.check_collision(
+                    t_node, self.obstacle_list, self.robot_radius):
                 safe_goal_inds.append(goal_ind)
 
         if not safe_goal_inds:
@@ -220,7 +224,8 @@ class RRTStar(RRT):
                 continue
             edge_node.cost = self.calc_new_cost(new_node, near_node)
 
-            no_collision = self.check_collision(edge_node, self.obstacle_list, self.robot_radius)
+            no_collision = self.check_collision(
+                edge_node, self.obstacle_list, self.robot_radius)
             improved_cost = near_node.cost > edge_node.cost
 
             if no_collision and improved_cost:

--- a/PathPlanning/RRTStar/rrt_star.py
+++ b/PathPlanning/RRTStar/rrt_star.py
@@ -42,7 +42,8 @@ class RRTStar(RRT):
                  goal_sample_rate=20,
                  max_iter=300,
                  connect_circle_dist=50.0,
-                 search_until_max_iter=False):
+                 search_until_max_iter=False,
+                 robot_radius=0.0):
         """
         Setting Parameter
 
@@ -53,7 +54,7 @@ class RRTStar(RRT):
 
         """
         super().__init__(start, goal, obstacle_list, rand_area, expand_dis,
-                         path_resolution, goal_sample_rate, max_iter)
+                         path_resolution, goal_sample_rate, max_iter, robot_radius=robot_radius)
         self.connect_circle_dist = connect_circle_dist
         self.goal_node = self.Node(goal[0], goal[1])
         self.search_until_max_iter = search_until_max_iter
@@ -77,7 +78,7 @@ class RRTStar(RRT):
                 math.hypot(new_node.x-near_node.x,
                            new_node.y-near_node.y)
 
-            if self.check_collision(new_node, self.obstacle_list):
+            if self.check_collision(new_node, self.obstacle_list, self.robot_radius):
                 near_inds = self.find_near_nodes(new_node)
                 node_with_updated_parent = self.choose_parent(
                     new_node, near_inds)
@@ -128,7 +129,7 @@ class RRTStar(RRT):
         for i in near_inds:
             near_node = self.node_list[i]
             t_node = self.steer(near_node, new_node)
-            if t_node and self.check_collision(t_node, self.obstacle_list):
+            if t_node and self.check_collision(t_node, self.obstacle_list, self.robot_radius):
                 costs.append(self.calc_new_cost(near_node, new_node))
             else:
                 costs.append(float("inf"))  # the cost of collision node
@@ -156,7 +157,7 @@ class RRTStar(RRT):
         safe_goal_inds = []
         for goal_ind in goal_inds:
             t_node = self.steer(self.node_list[goal_ind], self.goal_node)
-            if self.check_collision(t_node, self.obstacle_list):
+            if self.check_collision(t_node, self.obstacle_list, self.robot_radius):
                 safe_goal_inds.append(goal_ind)
 
         if not safe_goal_inds:
@@ -219,7 +220,7 @@ class RRTStar(RRT):
                 continue
             edge_node.cost = self.calc_new_cost(new_node, near_node)
 
-            no_collision = self.check_collision(edge_node, self.obstacle_list)
+            no_collision = self.check_collision(edge_node, self.obstacle_list, self.robot_radius)
             improved_cost = near_node.cost > edge_node.cost
 
             if no_collision and improved_cost:
@@ -264,7 +265,8 @@ def main():
         goal=[6, 10],
         rand_area=[-2, 15],
         obstacle_list=obstacle_list,
-        expand_dis=1)
+        expand_dis=1,
+        robot_radius=0.8)
     path = rrt_star.planning(animation=show_animation)
 
     if path is None:

--- a/PathPlanning/RRTStarDubins/rrt_star_dubins.py
+++ b/PathPlanning/RRTStarDubins/rrt_star_dubins.py
@@ -46,7 +46,8 @@ class RRTStarDubins(RRTStar):
     def __init__(self, start, goal, obstacle_list, rand_area,
                  goal_sample_rate=10,
                  max_iter=200,
-                 connect_circle_dist=50.0
+                 connect_circle_dist=50.0,
+                 robot_radius=0.0,
                  ):
         """
         Setting Parameter
@@ -69,6 +70,7 @@ class RRTStarDubins(RRTStar):
         self.curvature = 1.0  # for dubins path
         self.goal_yaw_th = np.deg2rad(1.0)
         self.goal_xy_th = 0.5
+        self.robot_radius = robot_radius
 
     def planning(self, animation=True, search_until_max_iter=True):
         """
@@ -84,7 +86,7 @@ class RRTStarDubins(RRTStar):
             nearest_ind = self.get_nearest_node_index(self.node_list, rnd)
             new_node = self.steer(self.node_list[nearest_ind], rnd)
 
-            if self.check_collision(new_node, self.obstacle_list):
+            if self.check_collision(new_node, self.obstacle_list, self.robot_radius):
                 near_indexes = self.find_near_nodes(new_node)
                 new_node = self.choose_parent(new_node, near_indexes)
                 if new_node:

--- a/PathPlanning/RRTStarDubins/rrt_star_dubins.py
+++ b/PathPlanning/RRTStarDubins/rrt_star_dubins.py
@@ -56,6 +56,7 @@ class RRTStarDubins(RRTStar):
         goal:Goal Position [x,y]
         obstacleList:obstacle Positions [[x,y,size],...]
         randArea:Random Sampling Area [min,max]
+        robot_radius: robot body modeled as circle with given radius
 
         """
         self.start = self.Node(start[0], start[1], start[2])

--- a/PathPlanning/RRTStarDubins/rrt_star_dubins.py
+++ b/PathPlanning/RRTStarDubins/rrt_star_dubins.py
@@ -86,7 +86,8 @@ class RRTStarDubins(RRTStar):
             nearest_ind = self.get_nearest_node_index(self.node_list, rnd)
             new_node = self.steer(self.node_list[nearest_ind], rnd)
 
-            if self.check_collision(new_node, self.obstacle_list, self.robot_radius):
+            if self.check_collision(
+                    new_node, self.obstacle_list, self.robot_radius):
                 near_indexes = self.find_near_nodes(new_node)
                 new_node = self.choose_parent(new_node, near_indexes)
                 if new_node:

--- a/PathPlanning/RRTStarReedsShepp/rrt_star_reeds_shepp.py
+++ b/PathPlanning/RRTStarReedsShepp/rrt_star_reeds_shepp.py
@@ -55,6 +55,7 @@ class RRTStarReedsShepp(RRTStar):
         goal:Goal Position [x,y]
         obstacleList:obstacle Positions [[x,y,size],...]
         randArea:Random Sampling Area [min,max]
+        robot_radius: robot body modeled as circle with given radius
 
         """
         self.start = self.Node(start[0], start[1], start[2])

--- a/PathPlanning/RRTStarReedsShepp/rrt_star_reeds_shepp.py
+++ b/PathPlanning/RRTStarReedsShepp/rrt_star_reeds_shepp.py
@@ -84,7 +84,8 @@ class RRTStarReedsShepp(RRTStar):
             nearest_ind = self.get_nearest_node_index(self.node_list, rnd)
             new_node = self.steer(self.node_list[nearest_ind], rnd)
 
-            if self.check_collision(new_node, self.obstacle_list, self.robot_radius):
+            if self.check_collision(
+                    new_node, self.obstacle_list, self.robot_radius):
                 near_indexes = self.find_near_nodes(new_node)
                 new_node = self.choose_parent(new_node, near_indexes)
                 if new_node:
@@ -119,7 +120,8 @@ class RRTStarReedsShepp(RRTStar):
         if new_node is None:
             return
 
-        if self.check_collision(new_node, self.obstacle_list, self.robot_radius):
+        if self.check_collision(
+                new_node, self.obstacle_list, self.robot_radius):
             self.node_list.append(new_node)
 
     def draw_graph(self, rnd=None):

--- a/PathPlanning/RRTStarReedsShepp/rrt_star_reeds_shepp.py
+++ b/PathPlanning/RRTStarReedsShepp/rrt_star_reeds_shepp.py
@@ -45,7 +45,8 @@ class RRTStarReedsShepp(RRTStar):
 
     def __init__(self, start, goal, obstacle_list, rand_area,
                  max_iter=200,
-                 connect_circle_dist=50.0
+                 connect_circle_dist=50.0,
+                 robot_radius=0.0
                  ):
         """
         Setting Parameter
@@ -63,6 +64,7 @@ class RRTStarReedsShepp(RRTStar):
         self.max_iter = max_iter
         self.obstacle_list = obstacle_list
         self.connect_circle_dist = connect_circle_dist
+        self.robot_radius = robot_radius
 
         self.curvature = 1.0
         self.goal_yaw_th = np.deg2rad(1.0)
@@ -82,7 +84,7 @@ class RRTStarReedsShepp(RRTStar):
             nearest_ind = self.get_nearest_node_index(self.node_list, rnd)
             new_node = self.steer(self.node_list[nearest_ind], rnd)
 
-            if self.check_collision(new_node, self.obstacle_list):
+            if self.check_collision(new_node, self.obstacle_list, self.robot_radius):
                 near_indexes = self.find_near_nodes(new_node)
                 new_node = self.choose_parent(new_node, near_indexes)
                 if new_node:
@@ -117,7 +119,7 @@ class RRTStarReedsShepp(RRTStar):
         if new_node is None:
             return
 
-        if self.check_collision(new_node, self.obstacle_list):
+        if self.check_collision(new_node, self.obstacle_list, self.robot_radius):
             self.node_list.append(new_node)
 
     def draw_graph(self, rnd=None):

--- a/tests/test_rrt_star.py
+++ b/tests/test_rrt_star.py
@@ -18,6 +18,18 @@ def test_no_obstacle():
     path = rrt_star.planning(animation=False)
     assert path is not None
 
+def test_no_obstacle_and_robot_radius():
+    obstacle_list = []
+
+    # Set Initial parameters
+    rrt_star = m.RRTStar(start=[0, 0],
+                         goal=[6, 10],
+                         rand_area=[-2, 15],
+                         obstacle_list=obstacle_list,
+                         robot_radius=0.8)
+    path = rrt_star.planning(animation=False)
+    assert path is not None
+
 
 if __name__ == '__main__':
     conftest.run_this_test(__file__)

--- a/tests/test_rrt_star.py
+++ b/tests/test_rrt_star.py
@@ -18,6 +18,7 @@ def test_no_obstacle():
     path = rrt_star.planning(animation=False)
     assert path is not None
 
+
 def test_no_obstacle_and_robot_radius():
     obstacle_list = []
 

--- a/tests/test_rrt_star_reeds_shepp.py
+++ b/tests/test_rrt_star_reeds_shepp.py
@@ -1,5 +1,5 @@
 import conftest  # Add root path to sys.path
-import rrt_star_reeds_shepp as m
+from PathPlanning.RRTStarReedsShepp import rrt_star_reeds_shepp as m
 
 
 def test1():


### PR DESCRIPTION
* update `__init__` and `check_collision` in RRT class to include a robot radius
* during animation, if a robot radius is given then it is drawn

#### What does this implement?

This simply adds an optional robot radius feature for the RRT/RRTStar path planners. 

#### Additional information

Examples updated to highlight feature.

#### CheckList
- [x] Did you add an unittest for your new example or defect fix? The radius feature is optional so should not break anything. I added an additional test in `test_rrt_star.py`
- [x] Did you add documents for your new example?
- [x] All CIs are green? (You can check it after submitting)
