### PR TITLE
modify the error of end node's state in DStar

### DIFF
--- a/PathPlanning/DStar/dstar.py
+++ b/PathPlanning/DStar/dstar.py
@@ -160,7 +160,7 @@ class Dstar:
         rx = []
         ry = []
 
-        self.open_list.add(end)
+        self.insert(end, 0.0)
 
         while True:
             self.process_state()


### PR DESCRIPTION
#### Reference issue
https://github.com/AtsushiSakai/PythonRobotics/issues/657

#### What does this implement/fix?
- An error is found in "PathPlanning/DStar/dstar.py", line 163
- Before added into open_list, the end node's state should be set as "open". Otherwise, the end node's state is remained to be "new" and it's member "h" will be rewritten by it's neighbor nodes later since "new" means this node hasn't been processed.
- I create this pull request to modify this error. You can accept it or fix the error by yourself since there is only one line of codes being changed.

