### PR TITLE
fix error: 'numpy.ndarray' object has no attribute 'append'

### DIFF
--- a/Mapping/grid_map_lib/grid_map_lib.py
+++ b/Mapping/grid_map_lib/grid_map_lib.py
@@ -120,8 +120,8 @@ class GridMap:
 
         # making ring polygon
         if (pol_x[0] != pol_x[-1]) or (pol_y[0] != pol_y[-1]):
-            pol_x.append(pol_x[0])
-            pol_y.append(pol_y[0])
+            np.append(pol_x, pol_x[0])
+            np.append(pol_y, pol_y[0])
 
         # setting value for all grid
         for x_ind in range(self.width):

--- a/tests/test_grid_map_lib.py
+++ b/tests/test_grid_map_lib.py
@@ -1,4 +1,5 @@
 from Mapping.grid_map_lib.grid_map_lib import GridMap
+import numpy as np
 
 
 def test_position_set():
@@ -19,6 +20,7 @@ def test_polygon_set():
     grid_map = GridMap(600, 290, 0.7, 60.0, 30.5)
 
     grid_map.set_value_from_polygon(ox, oy, 1.0, inside=False)
+    grid_map.set_value_from_polygon(np.array(ox), np.array(oy), 1.0, inside=False)
 
 
 if __name__ == '__main__':

--- a/tests/test_grid_map_lib.py
+++ b/tests/test_grid_map_lib.py
@@ -20,7 +20,8 @@ def test_polygon_set():
     grid_map = GridMap(600, 290, 0.7, 60.0, 30.5)
 
     grid_map.set_value_from_polygon(ox, oy, 1.0, inside=False)
-    grid_map.set_value_from_polygon(np.array(ox), np.array(oy), 1.0, inside=False)
+    grid_map.set_value_from_polygon(np.array(ox), np.array(oy),
+                                    1.0, inside=False)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION

<!-- 
Thanks for contributing a pull request! 
Please check this document before submitting:
- [How to contribute](https://pythonrobotics.readthedocs.io/en/latest/how_to_contribute.html#adding-a-new-algorithm-example)

Note that this is my hobby project; I appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
fix error: 'numpy.ndarray' object has no attribute 'append'

#### What does this implement/fix?
When running `grid_based_sweep_coverage_path_planner.py` and giving `ox` and `oy` without `ox[0] == ox[-1]`, you will get `fix error: 'numpy.ndarray' object has no attribute 'append'`

#### Additional information
<!--Any additional information you think is important.-->

#### CheckList
-[] Did you add an unittest for your new example or defect fix?
-[] Did you add documents for your new example?
-[] All CIs are green? (You can check it after submitting)
