### PR TITLE
docs: Fix a few typos

### DIFF
--- a/ArmNavigation/arm_obstacle_navigation/arm_obstacle_navigation.py
+++ b/ArmNavigation/arm_obstacle_navigation/arm_obstacle_navigation.py
@@ -105,7 +105,7 @@ def astar_torus(grid, start_node, goal_node):
 
     Args:
         grid: An occupancy grid (ndarray)
-        start_node: Initial joint configuation (tuple)
+        start_node: Initial joint configuration (tuple)
         goal_node: Goal joint configuration (tuple)
 
     Returns:

--- a/ArmNavigation/arm_obstacle_navigation/arm_obstacle_navigation_2.py
+++ b/ArmNavigation/arm_obstacle_navigation/arm_obstacle_navigation_2.py
@@ -136,7 +136,7 @@ def astar_torus(grid, start_node, goal_node):
 
     Args:
         grid: An occupancy grid (ndarray)
-        start_node: Initial joint configuation (tuple)
+        start_node: Initial joint configuration (tuple)
         goal_node: Goal joint configuration (tuple)
 
     Returns:

--- a/docs/modules/slam/FastSLAM1/FastSLAM1_main.rst
+++ b/docs/modules/slam/FastSLAM1/FastSLAM1_main.rst
@@ -39,7 +39,7 @@ an array of landmark locations
 -  The blue line is the true trajectory
 -  The red line is the estimated trajectory
 -  The red dots represent the distribution of particles
--  The black line represent dead reckoning tracjectory
+-  The black line represent dead reckoning trajectory
 -  The blue x is the observed and estimated landmarks
 -  The black x is the true landmark
 

--- a/docs/modules/slam/ekf_slam/ekf_slam_main.rst
+++ b/docs/modules/slam/ekf_slam/ekf_slam_main.rst
@@ -151,7 +151,7 @@ values incorporate the error into the estimation.
 
 :math:`\begin{equation*} X_{DR} = FX + B(U + R) \end{equation*}`
 
-The implementation of the motion model prediciton code is shown in
+The implementation of the motion model prediction code is shown in
 ``motion_model``. The ``observation`` function shows how the simulation
 uses (or doesn’t use) the process noise ``Rsim`` to the find the ground
 truth and dead reckoning estimates of the pose.


### PR DESCRIPTION
There are small typos in:
- ArmNavigation/arm_obstacle_navigation/arm_obstacle_navigation.py
- ArmNavigation/arm_obstacle_navigation/arm_obstacle_navigation_2.py
- docs/modules/slam/FastSLAM1/FastSLAM1_main.rst
- docs/modules/slam/ekf_slam/ekf_slam_main.rst

Fixes:
- Should read `configuration` rather than `configuation`.
- Should read `trajectory` rather than `tracjectory`.
- Should read `prediction` rather than `prediciton`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md