### PR TITLE
add axes3d to figure

### DIFF
--- a/Bipedal/bipedal_planner/bipedal_planner.py
+++ b/Bipedal/bipedal_planner/bipedal_planner.py
@@ -51,6 +51,7 @@ class BipedalPlanner(object):
         if plot:
             fig = plt.figure()
             ax = Axes3D(fig)
+            fig.add_axes(ax)
             com_trajectory_for_plot = []
 
         px, py = 0.0, 0.0  # reference footstep position


### PR DESCRIPTION
#### What does this implement/fix?
The Bipedal Planner code won't show the drawing. The reason is that since Matplotlib V3.4.0, Axes3D automatically adding itself to Figure is deprecated. The fix here is to add the axes3d to figure manually.

#### Additional information
Reference reading: https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.4.0.html

