### PR TITLE
Fix the rewire of rrt* path planning using reeds shepp curves (#550)

### DIFF
--- a/PathPlanning/RRTStar/rrt_star.py
+++ b/PathPlanning/RRTStar/rrt_star.py
@@ -226,6 +226,9 @@ class RRTStar(RRT):
             improved_cost = near_node.cost > edge_node.cost
 
             if no_collision and improved_cost:
+                for node in self.node_list:
+                    if node.parent == self.node_list[i]:
+                        node.parent = edge_node
                 self.node_list[i] = edge_node
                 self.node_list[i].cost = self.calc_new_cost(new_node, self.node_list[i])
                 self.propagate_cost_to_leaves(self.node_list[i])

--- a/PathPlanning/RRTStar/rrt_star.py
+++ b/PathPlanning/RRTStar/rrt_star.py
@@ -227,7 +227,8 @@ class RRTStar(RRT):
 
             if no_collision and improved_cost:
                 self.node_list[i] = edge_node
-        self.propagate_cost_to_leaves(new_node)
+                self.node_list[i].cost = self.calc_new_cost(new_node, self.node_list[i])
+                self.propagate_cost_to_leaves(self.node_list[i])
 
     def calc_new_cost(self, from_node, to_node):
         d, _ = self.calc_distance_and_angle(from_node, to_node)

--- a/PathPlanning/RRTStar/rrt_star.py
+++ b/PathPlanning/RRTStar/rrt_star.py
@@ -225,13 +225,8 @@ class RRTStar(RRT):
             improved_cost = near_node.cost > edge_node.cost
 
             if no_collision and improved_cost:
-                near_node.x = edge_node.x
-                near_node.y = edge_node.y
-                near_node.cost = edge_node.cost
-                near_node.path_x = edge_node.path_x
-                near_node.path_y = edge_node.path_y
-                near_node.parent = edge_node.parent
-                self.propagate_cost_to_leaves(new_node)
+                self.node_list[i] = edge_node
+        self.propagate_cost_to_leaves(new_node)
 
     def calc_new_cost(self, from_node, to_node):
         d, _ = self.calc_distance_and_angle(from_node, to_node)

--- a/PathPlanning/RRTStar/rrt_star.py
+++ b/PathPlanning/RRTStar/rrt_star.py
@@ -3,6 +3,7 @@
 Path planning Sample Code with RRT*
 
 author: Atsushi Sakai(@Atsushi_twi)
+        RyderCRD (SUSTech EEE5058)
 
 """
 

--- a/PathPlanning/RRTStarReedsShepp/rrt_star_reeds_shepp.py
+++ b/PathPlanning/RRTStarReedsShepp/rrt_star_reeds_shepp.py
@@ -165,7 +165,7 @@ class RRTStarReedsShepp(RRTStar):
         new_node.parent = from_node
 
         return new_node
-    
+
     def rewire(self, new_node, near_inds):
         for i in near_inds:
             near_node = self.node_list[i]

--- a/PathPlanning/RRTStarReedsShepp/rrt_star_reeds_shepp.py
+++ b/PathPlanning/RRTStarReedsShepp/rrt_star_reeds_shepp.py
@@ -171,23 +171,6 @@ class RRTStarReedsShepp(RRTStar):
 
         return new_node
 
-    def rewire(self, new_node, near_inds):
-        for i in near_inds:
-            near_node = self.node_list[i]
-            edge_node = self.steer(new_node, near_node)
-            if not edge_node:
-                continue
-            edge_node.cost = self.calc_new_cost(new_node, near_node)
-
-            no_collision = self.check_collision(
-                edge_node, self.obstacle_list, self.robot_radius)
-            improved_cost = near_node.cost > edge_node.cost
-
-            if no_collision and improved_cost:
-                self.node_list[i] = edge_node
-                self.node_list[i].cost = self.calc_new_cost(new_node, self.node_list[i])
-                self.propagate_cost_to_leaves(self.node_list[i])
-
     def calc_new_cost(self, from_node, to_node):
 
         _, _, _, _, course_lengths = reeds_shepp_path_planning.reeds_shepp_path_planning(

--- a/PathPlanning/RRTStarReedsShepp/rrt_star_reeds_shepp.py
+++ b/PathPlanning/RRTStarReedsShepp/rrt_star_reeds_shepp.py
@@ -165,6 +165,28 @@ class RRTStarReedsShepp(RRTStar):
         new_node.parent = from_node
 
         return new_node
+    
+    def rewire(self, new_node, near_inds):
+        for i in near_inds:
+            near_node = self.node_list[i]
+            edge_node = self.steer(new_node, near_node)
+            if not edge_node:
+                continue
+            edge_node.cost = self.calc_new_cost(new_node, near_node)
+
+            no_collision = self.check_collision(
+                edge_node, self.obstacle_list, self.robot_radius)
+            improved_cost = near_node.cost > edge_node.cost
+
+            if no_collision and improved_cost:
+                near_node.x = edge_node.x
+                near_node.y = edge_node.y
+                near_node.cost = edge_node.cost
+                near_node.path_x = edge_node.path_x
+                near_node.path_y = edge_node.path_y
+                near_node.path_yaw = edge_node.path_yaw
+                near_node.parent = edge_node.parent
+                self.propagate_cost_to_leaves(new_node)
 
     def calc_new_cost(self, from_node, to_node):
 

--- a/PathPlanning/RRTStarReedsShepp/rrt_star_reeds_shepp.py
+++ b/PathPlanning/RRTStarReedsShepp/rrt_star_reeds_shepp.py
@@ -244,10 +244,7 @@ class RRTStarReedsShepp(RRTStar):
         return path
 
 
-def main(max_iter=100, random_seed=None):
-    if random_seed:
-        random.seed(random_seed)
-
+def main(max_iter=100):
     print("Start " + __file__)
 
     # ====Search Path with RRT====

--- a/PathPlanning/RRTStarReedsShepp/rrt_star_reeds_shepp.py
+++ b/PathPlanning/RRTStarReedsShepp/rrt_star_reeds_shepp.py
@@ -3,6 +3,7 @@
 Path planning Sample Code with RRT with Reeds-Shepp path
 
 author: AtsushiSakai(@Atsushi_twi)
+        RyderCRD (SUSTech EEE5058)
 
 """
 import copy

--- a/PathPlanning/RRTStarReedsShepp/rrt_star_reeds_shepp.py
+++ b/PathPlanning/RRTStarReedsShepp/rrt_star_reeds_shepp.py
@@ -185,7 +185,8 @@ class RRTStarReedsShepp(RRTStar):
 
             if no_collision and improved_cost:
                 self.node_list[i] = edge_node
-        self.propagate_cost_to_leaves(new_node)
+                self.node_list[i].cost = self.calc_new_cost(new_node, self.node_list[i])
+                self.propagate_cost_to_leaves(self.node_list[i])
 
     def calc_new_cost(self, from_node, to_node):
 

--- a/PathPlanning/RRTStarReedsShepp/rrt_star_reeds_shepp.py
+++ b/PathPlanning/RRTStarReedsShepp/rrt_star_reeds_shepp.py
@@ -245,7 +245,10 @@ class RRTStarReedsShepp(RRTStar):
         return path
 
 
-def main(max_iter=100):
+def main(max_iter=100, random_seed=None):
+    if random_seed:
+        random.seed(random_seed)
+
     print("Start " + __file__)
 
     # ====Search Path with RRT====

--- a/PathPlanning/ReedsSheppPath/reeds_shepp_path_planning.py
+++ b/PathPlanning/ReedsSheppPath/reeds_shepp_path_planning.py
@@ -2,7 +2,8 @@
 
 Reeds Shepp path planner sample code
 
-author Atsushi Sakai(@Atsushi_twi)
+author: Atsushi Sakai(@Atsushi_twi)
+        RyderCRD (SUSTech EEE5058)
 
 """
 import math

--- a/PathPlanning/ReedsSheppPath/reeds_shepp_path_planning.py
+++ b/PathPlanning/ReedsSheppPath/reeds_shepp_path_planning.py
@@ -53,17 +53,14 @@ def mod2pi(x):
 
 def straight_left_straight(x, y, phi):
     phi = mod2pi(phi)
-    if y > 0.0 and 0.0 < phi < math.pi * 0.99:
+    # only take phi in (0.01*math.pi, 0.99*math.pi) for the sake of speed.
+    # phi in (0, 0.01*math.pi) will make test2() in test_rrt_star_reeds_shepp.py
+    # extremely time-consuming, since the value of xd, t will be very large.
+    if math.pi * 0.01 < phi < math.pi * 0.99 and np.sign(y) != 0:
         xd = - y / math.tan(phi) + x
         t = xd - math.tan(phi / 2.0)
         u = phi
-        v = math.hypot(x - xd, y) - math.tan(phi / 2.0)
-        return True, t, u, v
-    elif y < 0.0 < phi < math.pi * 0.99:
-        xd = - y / math.tan(phi) + x
-        t = xd - math.tan(phi / 2.0)
-        u = phi
-        v = -math.hypot(x - xd, y) - math.tan(phi / 2.0)
+        v = np.sign(y) * math.hypot(x - xd, y) - math.tan(phi / 2.0)
         return True, t, u, v
 
     return False, 0.0, 0.0, 0.0

--- a/tests/test_rrt_star_reeds_shepp.py
+++ b/tests/test_rrt_star_reeds_shepp.py
@@ -9,7 +9,7 @@ def test1():
 def test2():
     m.show_animation = False
     m.main(max_iter=30, random_seed=8)
-    
+
 
 if __name__ == '__main__':
     conftest.run_this_test(__file__)

--- a/tests/test_rrt_star_reeds_shepp.py
+++ b/tests/test_rrt_star_reeds_shepp.py
@@ -6,9 +6,42 @@ def test1():
     m.show_animation = False
     m.main(max_iter=5)
 
+obstacleList = [
+    (5, 5, 1),
+    (4, 6, 1),
+    (4, 8, 1),
+    (4, 10, 1),
+    (6, 5, 1),
+    (7, 5, 1),
+    (8, 6, 1),
+    (8, 8, 1),
+    (8, 10, 1)
+]  # [x,y,size(radius)]
+
+start = [0.0, 0.0, m.np.deg2rad(0.0)]
+goal = [6.0, 7.0, m.np.deg2rad(90.0)]
+
 def test2():
-    m.show_animation = False
-    m.main(max_iter=30, random_seed=8)
+    step_size = 0.2
+    rrt_star_reeds_shepp = m.RRTStarReedsShepp(start, goal,
+                                             obstacleList, [-2.0, 15.0],
+                                             max_iter=100, step_size=step_size)
+    rrt_star_reeds_shepp.set_random_seed(seed=8)
+    path = rrt_star_reeds_shepp.planning(animation=False)
+    for i in range(len(path)-1):
+        # + 0.00000000000001 for acceptable errors arising from the planning process
+        assert m.math.dist(path[i][0:2], path[i+1][0:2]) < step_size + 0.00000000000001
+
+def test3():
+    step_size = 20
+    rrt_star_reeds_shepp = m.RRTStarReedsShepp(start, goal,
+                                             obstacleList, [-2.0, 15.0],
+                                             max_iter=100, step_size=step_size)
+    rrt_star_reeds_shepp.set_random_seed(seed=8)
+    path = rrt_star_reeds_shepp.planning(animation=False)
+    for i in range(len(path)-1):
+        # + 0.00000000000001 for acceptable errors arising from the planning process
+        assert m.math.dist(path[i][0:2], path[i+1][0:2]) < step_size + 0.00000000000001
 
 
 if __name__ == '__main__':

--- a/tests/test_rrt_star_reeds_shepp.py
+++ b/tests/test_rrt_star_reeds_shepp.py
@@ -6,6 +6,10 @@ def test1():
     m.show_animation = False
     m.main(max_iter=5)
 
+def test2():
+    m.show_animation = False
+    m.main(max_iter=30, random_seed=8)
+    
 
 if __name__ == '__main__':
     conftest.run_this_test(__file__)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! 
Please check this document before submitting:
- [How to contribute](https://atsushisakai.github.io/PythonRobotics/how_to_contribute.html#adding-a-new-algorithm-example)

Note that this is my hobby project; I appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: fix #392-->
fix #550 

#### What does this implement/fix?
<!--Please explain your changes.-->
rrt_star_reeds_shepp.py needs its own version of rewire(), which not only updates path_x , path_y, but also path_yaw when rewiring. 
Before this pull request, it uses the rewire() in rrt_star.py, which only cares about path_x, and path_y, thus issue #550 might occur.

The range of phi in rrt_star_reeds_shepp.py is changed from (0, 0.99\*math.pi) to (0.01\*math.pi, 0.99*math.pi) for the sake of speed.

#### Additional information
<!--Any additional information you think is important.-->
A unit test is added into tests/test_rrt_star_reeds_shepp.py.

#### CheckList
- [x] Did you add an unittest for your new example or defect fix?
- [x] Did you add documents for your new example?
- [x] All CIs are green? (You can check it after submitting)
