### PR TITLE
Fix the rewire() of rrt* path planning (#550) 

### DIFF
--- a/PathPlanning/RRTStar/rrt_star.py
+++ b/PathPlanning/RRTStar/rrt_star.py
@@ -3,6 +3,7 @@
 Path planning Sample Code with RRT*
 
 author: Atsushi Sakai(@Atsushi_twi)
+        RyderCRD (SUSTech EEE5058)
 
 """
 
@@ -225,13 +226,12 @@ class RRTStar(RRT):
             improved_cost = near_node.cost > edge_node.cost
 
             if no_collision and improved_cost:
-                near_node.x = edge_node.x
-                near_node.y = edge_node.y
-                near_node.cost = edge_node.cost
-                near_node.path_x = edge_node.path_x
-                near_node.path_y = edge_node.path_y
-                near_node.parent = edge_node.parent
-                self.propagate_cost_to_leaves(new_node)
+                for node in self.node_list:
+                    if node.parent == self.node_list[i]:
+                        node.parent = edge_node
+                self.node_list[i] = edge_node
+                self.node_list[i].cost = self.calc_new_cost(new_node, self.node_list[i])
+                self.propagate_cost_to_leaves(self.node_list[i])
 
     def calc_new_cost(self, from_node, to_node):
         d, _ = self.calc_distance_and_angle(from_node, to_node)

--- a/PathPlanning/RRTStar/rrt_star.py
+++ b/PathPlanning/RRTStar/rrt_star.py
@@ -3,7 +3,6 @@
 Path planning Sample Code with RRT*
 
 author: Atsushi Sakai(@Atsushi_twi)
-        RyderCRD (SUSTech EEE5058)
 
 """
 
@@ -230,7 +229,6 @@ class RRTStar(RRT):
                     if node.parent == self.node_list[i]:
                         node.parent = edge_node
                 self.node_list[i] = edge_node
-                self.node_list[i].cost = self.calc_new_cost(new_node, self.node_list[i])
                 self.propagate_cost_to_leaves(self.node_list[i])
 
     def calc_new_cost(self, from_node, to_node):

--- a/PathPlanning/RRTStarReedsShepp/rrt_star_reeds_shepp.py
+++ b/PathPlanning/RRTStarReedsShepp/rrt_star_reeds_shepp.py
@@ -3,7 +3,6 @@
 Path planning Sample Code with RRT with Reeds-Shepp path
 
 author: AtsushiSakai(@Atsushi_twi)
-        RyderCRD (SUSTech EEE5058)
 
 """
 import copy

--- a/PathPlanning/RRTStarReedsShepp/rrt_star_reeds_shepp.py
+++ b/PathPlanning/RRTStarReedsShepp/rrt_star_reeds_shepp.py
@@ -3,6 +3,7 @@
 Path planning Sample Code with RRT with Reeds-Shepp path
 
 author: AtsushiSakai(@Atsushi_twi)
+        RyderCRD (SUSTech EEE5058)
 
 """
 import copy
@@ -36,7 +37,7 @@ class RRTStarReedsShepp(RRTStar):
             self.path_yaw = []
 
     def __init__(self, start, goal, obstacle_list, rand_area,
-                 max_iter=200,
+                 max_iter=200, step_size=0.2,
                  connect_circle_dist=50.0,
                  robot_radius=0.0
                  ):
@@ -55,6 +56,7 @@ class RRTStarReedsShepp(RRTStar):
         self.min_rand = rand_area[0]
         self.max_rand = rand_area[1]
         self.max_iter = max_iter
+        self.step_size = step_size
         self.obstacle_list = obstacle_list
         self.connect_circle_dist = connect_circle_dist
         self.robot_radius = robot_radius
@@ -62,6 +64,9 @@ class RRTStarReedsShepp(RRTStar):
         self.curvature = 1.0
         self.goal_yaw_th = np.deg2rad(1.0)
         self.goal_xy_th = 0.5
+
+    def set_random_seed(self, seed):
+        random.seed(seed)
 
     def planning(self, animation=True, search_until_max_iter=True):
         """
@@ -147,8 +152,8 @@ class RRTStarReedsShepp(RRTStar):
     def steer(self, from_node, to_node):
 
         px, py, pyaw, mode, course_lengths = reeds_shepp_path_planning.reeds_shepp_path_planning(
-            from_node.x, from_node.y, from_node.yaw,
-            to_node.x, to_node.y, to_node.yaw, self.curvature)
+            from_node.x, from_node.y, from_node.yaw, to_node.x,
+            to_node.y, to_node.yaw, self.curvature, self.step_size)
 
         if not px:
             return None
@@ -169,8 +174,8 @@ class RRTStarReedsShepp(RRTStar):
     def calc_new_cost(self, from_node, to_node):
 
         _, _, _, _, course_lengths = reeds_shepp_path_planning.reeds_shepp_path_planning(
-            from_node.x, from_node.y, from_node.yaw,
-            to_node.x, to_node.y, to_node.yaw, self.curvature)
+            from_node.x, from_node.y, from_node.yaw, to_node.x,
+            to_node.y, to_node.yaw, self.curvature, self.step_size)
         if not course_lengths:
             return float("inf")
 

--- a/PathPlanning/ReedsSheppPath/reeds_shepp_path_planning.py
+++ b/PathPlanning/ReedsSheppPath/reeds_shepp_path_planning.py
@@ -57,7 +57,7 @@ def straight_left_straight(x, y, phi):
     # only take phi in (0.01*math.pi, 0.99*math.pi) for the sake of speed.
     # phi in (0, 0.01*math.pi) will make test2() in test_rrt_star_reeds_shepp.py
     # extremely time-consuming, since the value of xd, t will be very large.
-    if math.pi * 0.01 < phi < math.pi * 0.99 and np.sign(y) != 0:
+    if math.pi * 0.01 < phi < math.pi * 0.99 and y != 0:
         xd = - y / math.tan(phi) + x
         t = xd - math.tan(phi / 2.0)
         u = phi

--- a/PathPlanning/ReedsSheppPath/reeds_shepp_path_planning.py
+++ b/PathPlanning/ReedsSheppPath/reeds_shepp_path_planning.py
@@ -2,7 +2,7 @@
 
 Reeds Shepp path planner sample code
 
-author: Atsushi Sakai(@Atsushi_twi)
+author Atsushi Sakai(@Atsushi_twi)
 
 """
 import math

--- a/PathPlanning/ReedsSheppPath/reeds_shepp_path_planning.py
+++ b/PathPlanning/ReedsSheppPath/reeds_shepp_path_planning.py
@@ -2,7 +2,8 @@
 
 Reeds Shepp path planner sample code
 
-author Atsushi Sakai(@Atsushi_twi)
+author: Atsushi Sakai(@Atsushi_twi)
+        RyderCRD (SUSTech EEE5058)
 
 """
 import math
@@ -53,17 +54,14 @@ def mod2pi(x):
 
 def straight_left_straight(x, y, phi):
     phi = mod2pi(phi)
-    if y > 0.0 and 0.0 < phi < math.pi * 0.99:
+    # only take phi in (0.01*math.pi, 0.99*math.pi) for the sake of speed.
+    # phi in (0, 0.01*math.pi) will make test2() in test_rrt_star_reeds_shepp.py
+    # extremely time-consuming, since the value of xd, t will be very large.
+    if math.pi * 0.01 < phi < math.pi * 0.99 and np.sign(y) != 0:
         xd = - y / math.tan(phi) + x
         t = xd - math.tan(phi / 2.0)
         u = phi
-        v = math.hypot(x - xd, y) - math.tan(phi / 2.0)
-        return True, t, u, v
-    elif y < 0.0 < phi < math.pi * 0.99:
-        xd = - y / math.tan(phi) + x
-        t = xd - math.tan(phi / 2.0)
-        u = phi
-        v = -math.hypot(x - xd, y) - math.tan(phi / 2.0)
+        v = np.sign(y) * math.hypot(x - xd, y) - math.tan(phi / 2.0)
         return True, t, u, v
 
     return False, 0.0, 0.0, 0.0

--- a/PathPlanning/ReedsSheppPath/reeds_shepp_path_planning.py
+++ b/PathPlanning/ReedsSheppPath/reeds_shepp_path_planning.py
@@ -3,7 +3,6 @@
 Reeds Shepp path planner sample code
 
 author: Atsushi Sakai(@Atsushi_twi)
-        RyderCRD (SUSTech EEE5058)
 
 """
 import math

--- a/tests/test_rrt_star_reeds_shepp.py
+++ b/tests/test_rrt_star_reeds_shepp.py
@@ -6,6 +6,43 @@ def test1():
     m.show_animation = False
     m.main(max_iter=5)
 
+obstacleList = [
+    (5, 5, 1),
+    (4, 6, 1),
+    (4, 8, 1),
+    (4, 10, 1),
+    (6, 5, 1),
+    (7, 5, 1),
+    (8, 6, 1),
+    (8, 8, 1),
+    (8, 10, 1)
+]  # [x,y,size(radius)]
+
+start = [0.0, 0.0, m.np.deg2rad(0.0)]
+goal = [6.0, 7.0, m.np.deg2rad(90.0)]
+
+def test2():
+    step_size = 0.2
+    rrt_star_reeds_shepp = m.RRTStarReedsShepp(start, goal,
+                                             obstacleList, [-2.0, 15.0],
+                                             max_iter=100, step_size=step_size)
+    rrt_star_reeds_shepp.set_random_seed(seed=8)
+    path = rrt_star_reeds_shepp.planning(animation=False)
+    for i in range(len(path)-1):
+        # + 0.00000000000001 for acceptable errors arising from the planning process
+        assert m.math.dist(path[i][0:2], path[i+1][0:2]) < step_size + 0.00000000000001
+
+def test3():
+    step_size = 20
+    rrt_star_reeds_shepp = m.RRTStarReedsShepp(start, goal,
+                                             obstacleList, [-2.0, 15.0],
+                                             max_iter=100, step_size=step_size)
+    rrt_star_reeds_shepp.set_random_seed(seed=8)
+    path = rrt_star_reeds_shepp.planning(animation=False)
+    for i in range(len(path)-1):
+        # + 0.00000000000001 for acceptable errors arising from the planning process
+        assert m.math.dist(path[i][0:2], path[i+1][0:2]) < step_size + 0.00000000000001
+
 
 if __name__ == '__main__':
     conftest.run_this_test(__file__)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! 
Please check this document before submitting:
- [How to contribute](https://atsushisakai.github.io/PythonRobotics/how_to_contribute.html#adding-a-new-algorithm-example)

Note that this is my hobby project; I appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: fix #392-->
fix #550 

#### What does this implement/fix?
<!--Please explain your changes.-->
rrt_star_reeds_shepp.py needs its own version of rewire(), which not only updates path_x , path_y, but also path_yaw when rewiring. 
Before this pull request, it uses the rewire() in rrt_star.py, which only cares about path_x, and path_y, thus issue #550 might occur.

The range of phi in rrt_star_reeds_shepp.py is changed from (0, 0.99\*math.pi) to (0.01\*math.pi, 0.99*math.pi) for the sake of speed.

#### Additional information
<!--Any additional information you think is important.-->
Two tests are added into tests/test_rrt_star_reeds_shepp.py.

#### CheckList
- [x] Did you add an unittest for your new example or defect fix?
- [x] Did you add documents for your new example?
- [x] All CIs are green? (You can check it after submitting)
