### PR TITLE
fix added for checking if a neighbor is inside openList

### DIFF
--- a/PathPlanning/HybridAStar/hybrid_a_star.py
+++ b/PathPlanning/HybridAStar/hybrid_a_star.py
@@ -311,7 +311,7 @@ def hybrid_a_star_planning(start, goal, ox, oy, xy_resolution, yaw_resolution):
             neighbor_index = calc_index(neighbor, config)
             if neighbor_index in closedList:
                 continue
-            if neighbor not in openList \
+            if neighbor_index not in openList \
                     or openList[neighbor_index].cost > neighbor.cost:
                 heapq.heappush(
                     pq, (calc_cost(neighbor, h_dp, config),


### PR DESCRIPTION
#### Reference issue
Fix #831 

#### What does this implement/fix?
This fixes the problem about checking if a node is inside the open_list dictionary. Before the fix, the check actually does not mean anything because it never gives false.  
Before the fix: 
![result-before](https://github.com/AtsushiSakai/PythonRobotics/assets/70749779/198b0e6f-c0f2-4909-b350-0b0937de2ea2)
After the fix: 
![Result-after](https://github.com/AtsushiSakai/PythonRobotics/assets/70749779/289d51f5-6478-4af9-9f90-e5f9e7dc9007)

It seems like it is now faster and it finds a safer path. 

#### Additional information
<!--Any additional information you think is important.-->

#### CheckList
- [ ] All CIs are green? (You can check it after submitting)
