### PR TITLE
Add dark mode feature in documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,6 +46,7 @@ extensions = [
     'sphinx.ext.imgconverter',
     'IPython.sphinxext.ipython_console_highlighting',
     'sphinx_copybutton',
+    'sphinx_rtd_dark_mode',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -86,7 +87,7 @@ on_rtd = os.environ.get('READTHEDOCS') == 'True'
 if on_rtd:
     html_theme = 'default'
 else:
-    html_theme = 'sphinx_rtd_theme'
+    html_theme = 'sphinx_rtd_light_them'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/doc_requirements.txt
+++ b/docs/doc_requirements.txt
@@ -3,3 +3,4 @@ sphinx_rtd_theme == 1.0.0
 IPython == 8.10.0 # For sphinx documentation
 sphinxcontrib-napoleon == 0.7 # For auto doc
 sphinx-copybutton
+sphinx-rtd-dark-mode


### PR DESCRIPTION
Many users prefer dark mode when they are reading documentation. Now, Users can choose their preferred color mode in documentation. By default, documentation mode will be in default mode, but the background will change when the user clicks the toggle button.

## Implementation : 

- pip install sphinx-rtd-dark-mode
- In conf.py configuration file, sphinx-rtd-dark-mode
 ``` extensions = [  'sphinx_rtd_dark_mode' ] ```
-  ``` html_theme = 'sphinx_rtd_light_theme' ```
- Also, I added the  sphinx-rtd-dark-mode package to the **doc_requirements.txt** file

## Changes : 
![ezgif com-video-to-gif (1)](https://github.com/AtsushiSakai/PythonRobotics/assets/51821426/654c950e-66be-41e7-aabc-fd0f5362e39f)
