### PR TITLE
Added: missing path types

### DIFF
--- a/PathPlanning/ModelPredictiveTrajectoryGenerator/trajectory_generator.py
+++ b/PathPlanning/ModelPredictiveTrajectoryGenerator/trajectory_generator.py
@@ -18,7 +18,7 @@ import ModelPredictiveTrajectoryGenerator.motion_model as motion_model
 
 # optimization parameter
 max_iter = 100
-h = np.array([0.5, 0.02, 0.02]).T  # parameter sampling distance
+h: np.ndarray = np.array([0.5, 0.02, 0.02]).T  # parameter sampling distance
 cost_th = 0.1
 
 show_animation = True

--- a/tests/test_rrt_star_reeds_shepp.py
+++ b/tests/test_rrt_star_reeds_shepp.py
@@ -39,8 +39,11 @@ def test3():
                                              max_iter=100, step_size=step_size)
     rrt_star_reeds_shepp.set_random_seed(seed=8)
     path = rrt_star_reeds_shepp.planning(animation=False)
-    assert path is None
+    for i in range(len(path)-1):
+        # + 0.00000000000001 for acceptable errors arising from the planning process
+        assert m.math.dist(path[i][0:2], path[i+1][0:2]) < step_size + 0.00000000000001
 
 
 if __name__ == '__main__':
-    conftest.run_this_test(__file__)
+    # conftest.run_this_test(__file__)
+    test3()

--- a/tests/test_rrt_star_reeds_shepp.py
+++ b/tests/test_rrt_star_reeds_shepp.py
@@ -45,5 +45,4 @@ def test3():
 
 
 if __name__ == '__main__':
-    # conftest.run_this_test(__file__)
-    test3()
+    conftest.run_this_test(__file__)

--- a/tests/test_rrt_star_reeds_shepp.py
+++ b/tests/test_rrt_star_reeds_shepp.py
@@ -39,9 +39,7 @@ def test3():
                                              max_iter=100, step_size=step_size)
     rrt_star_reeds_shepp.set_random_seed(seed=8)
     path = rrt_star_reeds_shepp.planning(animation=False)
-    for i in range(len(path)-1):
-        # + 0.00000000000001 for acceptable errors arising from the planning process
-        assert m.math.dist(path[i][0:2], path[i+1][0:2]) < step_size + 0.00000000000001
+    assert path is None
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
fix #892 

#### What does this implement/fix?
<!--Please explain your changes.-->

Added the missing RS paths in reeds_shepp_path_planning.py as mentioned in the issue.
Changed the function {generate_path} to make the code cleaner.
Removed these functions {curve_curve_curve, curve_straight_curve, straight_curve_straight}: To have a neat implementation and remove inaccurate path type.
Added these functions{reflect, timeflip}: To neatly consider the reflected and timeflipped paths as mentions in the paper.

Referred Paper: OPTIMAL PATHS FOR A CAR THAT GOES BOTH FORWARDS AND BACKWARDS - J. A. REEDS AND L. A. SHEPP [There were some formula typos in the paper]
Referred Code: https://github.com/nathanlct/reeds-shepp-curves/blob/master/reeds_shepp.py#L139

#### CheckList
- [ ] Did you add an unittest for your new example or defect fix?
- [ ] Did you add documents for your new example?
- [ ] All CIs are green? (You can check it after submitting)
