### PR TITLE
PathPlanning/InformedRRTStar/informed_rrt_star.py: Fix hard coded graph axis

### DIFF
--- a/PathPlanning/InformedRRTStar/informed_rrt_star.py
+++ b/PathPlanning/InformedRRTStar/informed_rrt_star.py
@@ -293,7 +293,7 @@ class InformedRRTStar:
 
         plt.plot(self.start.x, self.start.y, "xr")
         plt.plot(self.goal.x, self.goal.y, "xr")
-        plt.axis([-2, 15, -2, 15])
+        plt.axis([self.min_rand, self.max_rand, self.min_rand, self.max_rand])
         plt.grid(True)
         plt.pause(0.01)
 


### PR DESCRIPTION
Replacing the hard coded graph axis values with class variables

- Use self.min_rand, self.max_rand variable values in place of -2, 15

<!-- 
Thanks for contributing a pull request! 
Please check this document before submitting:
- [How to contribute](https://atsushisakai.github.io/PythonRobotics/how_to_contribute.html#adding-a-new-algorithm-example)

Note that this is my hobby project; I appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: fix #392-->

#### What does this implement/fix?
This replaces hard coded axis values of  -2, 15 with self.min_rand, self.max_rand class variables when drawing the graph

#### Additional information
This makes the function re-usable for varying sized graphs, beyond the example case in the main function

#### CheckList
- [ ] Did you add an unittest for your new example or defect fix?
- [ ] Did you add documents for your new example?
- [ ] All CIs are green? (You can check it after submitting)
