### PR TITLE
Fix: dead link URL in doc

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,4 +1,4 @@
 # These are supported funding model platforms
 github:  AtsushiSakai
 patreon: myenigma
-custom: https://www.paypal.me/myenigmapay/
+custom: https://www.paypal.com/paypalme/myenigmapay/

--- a/ArmNavigation/arm_obstacle_navigation/arm_obstacle_navigation.py
+++ b/ArmNavigation/arm_obstacle_navigation/arm_obstacle_navigation.py
@@ -34,7 +34,7 @@ def detect_collision(line_seg, circle):
     """
     Determines whether a line segment (arm link) is in contact
     with a circle (obstacle).
-    Credit to: http://doswa.com/2009/07/13/circle-segment-intersectioncollision.html
+    Credit to: https://web.archive.org/web/20200130224918/http://doswa.com/2009/07/13/circle-segment-intersectioncollision.html
     Args:
         line_seg: List of coordinates of line segment endpoints e.g. [[1, 1], [2, 2]]
         circle: List of circle coordinates and radius e.g. [0, 0, 0.5] is a circle centered

--- a/ArmNavigation/arm_obstacle_navigation/arm_obstacle_navigation_2.py
+++ b/ArmNavigation/arm_obstacle_navigation/arm_obstacle_navigation_2.py
@@ -66,7 +66,7 @@ def detect_collision(line_seg, circle):
     """
     Determines whether a line segment (arm link) is in contact
     with a circle (obstacle).
-    Credit to: http://doswa.com/2009/07/13/circle-segment-intersectioncollision.html
+    Credit to: https://web.archive.org/web/20200130224918/http://doswa.com/2009/07/13/circle-segment-intersectioncollision.html
     Args:
         line_seg: List of coordinates of line segment endpoints e.g. [[1, 1], [2, 2]]
         circle: List of circle coordinates and radius e.g. [0, 0, 0.5] is a circle centered

--- a/PathPlanning/BugPlanning/bug.py
+++ b/PathPlanning/BugPlanning/bug.py
@@ -1,7 +1,7 @@
 """
 Bug Planning
 author: Sarim Mehdi(muhammadsarim.mehdi@studio.unibo.it)
-Source: https://sites.google.com/site/ece452bugalgorithms/
+Source: https://web.archive.org/web/20201103052224/https://sites.google.com/site/ece452bugalgorithms/
 """
 
 import numpy as np

--- a/PathPlanning/DynamicMovementPrimitives/dynamic_movement_primitives.py
+++ b/PathPlanning/DynamicMovementPrimitives/dynamic_movement_primitives.py
@@ -9,7 +9,7 @@ stretch a curve by adjusting its start and end points.
 
 More information on Dynamic Movement Primitives available at:
 https://arxiv.org/abs/2102.03861
-https://www.frontiersin.org/articles/10.3389/fncom.2013.00138/full
+https://www.frontiersin.org/journals/computational-neuroscience/articles/10.3389/fncom.2013.00138/full
 
 """
 

--- a/PathPlanning/Eta3SplineTrajectory/eta3_spline_trajectory.py
+++ b/PathPlanning/Eta3SplineTrajectory/eta3_spline_trajectory.py
@@ -6,7 +6,7 @@ author: Joe Dinius, Ph.D (https://jwdinius.github.io)
         Atsushi Sakai (@Atsushi_twi)
 
 Refs:
-- https://jwdinius.github.io/blog/2018/eta3traj
+- https://jwdinius.github.io/blog/2018/eta3traj/
 - [eta^3-Splines for the Smooth Path Generation of Wheeled Mobile Robots]
 (https://ieeexplore.ieee.org/document/4339545/)
 

--- a/PathPlanning/InformedRRTStar/informed_rrt_star.py
+++ b/PathPlanning/InformedRRTStar/informed_rrt_star.py
@@ -6,7 +6,7 @@ author: Karan Chawla
 
 Reference: Informed RRT*: Optimal Sampling-based Path planning Focused via
 Direct Sampling of an Admissible Ellipsoidal Heuristic
-https://arxiv.org/pdf/1404.2334.pdf
+https://arxiv.org/pdf/1404.2334
 
 """
 import sys

--- a/PathPlanning/QuinticPolynomialsPlanner/quintic_polynomials_planner.py
+++ b/PathPlanning/QuinticPolynomialsPlanner/quintic_polynomials_planner.py
@@ -6,7 +6,7 @@ author: Atsushi Sakai (@Atsushi_twi)
 
 Ref:
 
-- [Local Path planning And Motion Control For Agv In Positioning](http://ieeexplore.ieee.org/document/637936/)
+- [Local Path planning And Motion Control For Agv In Positioning](https://ieeexplore.ieee.org/document/637936/)
 
 """
 

--- a/PathPlanning/RRT/sobol/sobol.py
+++ b/PathPlanning/RRT/sobol/sobol.py
@@ -13,7 +13,7 @@
     PYTHON versions by Corrado Chisari
 
     Original code is available at
-    http://people.sc.fsu.edu/~jburkardt/py_src/sobol/sobol.html
+    https://people.sc.fsu.edu/~jburkardt/py_src/sobol/sobol.html
 
     Note: the i4 prefix means that the function takes a numeric argument or
           returns a number which is interpreted inside the function as a 4

--- a/PathPlanning/StateLatticePlanner/state_lattice_planner.py
+++ b/PathPlanning/StateLatticePlanner/state_lattice_planner.py
@@ -12,8 +12,8 @@ Ref:
 
 - State Space Sampling of Feasible Motions for High-Performance Mobile Robot
 Navigation in Complex Environments
-http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.187.8210&rep=rep1
-&type=pdf
+https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf
+&doi=e2256b5b24137f89e473f01df288cb3aa72e56a0
 
 """
 import sys

--- a/PathPlanning/WavefrontCPP/wavefront_coverage_path_planner.py
+++ b/PathPlanning/WavefrontCPP/wavefront_coverage_path_planner.py
@@ -4,7 +4,7 @@ Distance/Path Transform Wavefront Coverage Path Planner
 author: Todd Tang
 paper: Planning paths of complete coverage of an unstructured environment
          by a mobile robot - Zelinsky et.al.
-link: http://pinkwink.kr/attachment/cfile3.uf@1354654A4E8945BD13FE77.pdf
+link: https://pinkwink.kr/attachment/cfile3.uf@1354654A4E8945BD13FE77.pdf
 """
 
 import os

--- a/PathTracking/cgmres_nmpc/cgmres_nmpc.py
+++ b/PathTracking/cgmres_nmpc/cgmres_nmpc.py
@@ -6,7 +6,7 @@ author Atsushi Sakai (@Atsushi_twi)
 
 Ref:
 Shunichi09/nonlinear_control: Implementing the nonlinear model predictive
-control, sliding mode control https://github.com/Shunichi09/nonlinear_control
+control, sliding mode control https://github.com/Shunichi09/PythonLinearNonlinearControl
 
 """
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 ![GitHub_Action_MacOS_CI](https://github.com/AtsushiSakai/PythonRobotics/workflows/MacOS_CI/badge.svg)
 ![GitHub_Action_Windows_CI](https://github.com/AtsushiSakai/PythonRobotics/workflows/Windows_CI/badge.svg)
 [![Build status](https://ci.appveyor.com/api/projects/status/sb279kxuv1be391g?svg=true)](https://ci.appveyor.com/project/AtsushiSakai/pythonrobotics)
-[![codecov](https://codecov.io/gh/AtsushiSakai/PythonRobotics/branch/master/graph/badge.svg)](https://codecov.io/gh/AtsushiSakai/PythonRobotics)
 
 Python codes for robotics algorithm.
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ For development:
   
 - [pytest-xdist](https://pypi.org/project/pytest-xdist/) (for parallel unit tests)
   
-- [mypy](http://mypy-lang.org/) (for type check)
+- [mypy](https://mypy-lang.org/) (for type check)
   
 - [sphinx](https://www.sphinx-doc.org/) (for document generation)
   
@@ -328,7 +328,7 @@ The animation shows a robot finding its path and rerouting to avoid obstacles as
 
 Refs:
 
-- [D* Lite](http://idm-lab.org/bib/abstracts/papers/aaai02b.pd)
+- [D* Lite](http://idm-lab.org/bib/abstracts/papers/aaai02b.pdf)
 - [Improved Fast Replanning for Robot Navigation in Unknown Terrain](http://www.cs.cmu.edu/~maxim/files/dlite_icra02.pdf)
 
 ### Potential Field algorithm
@@ -357,9 +357,9 @@ This code uses the model predictive trajectory generator to solve boundary probl
 
 Ref: 
 
-- [Optimal rough terrain trajectory generation for wheeled mobile robots](http://journals.sagepub.com/doi/pdf/10.1177/0278364906075328)
+- [Optimal rough terrain trajectory generation for wheeled mobile robots](https://journals.sagepub.com/doi/pdf/10.1177/0278364906075328)
 
-- [State Space Sampling of Feasible Motions for High-Performance Mobile Robot Navigation in Complex Environments](http://www.frc.ri.cmu.edu/~alonzo/pubs/papers/JFR_08_SS_Sampling.pdf)
+- [State Space Sampling of Feasible Motions for High-Performance Mobile Robot Navigation in Complex Environments](https://www.frc.ri.cmu.edu/~alonzo/pubs/papers/JFR_08_SS_Sampling.pdf)
 
 
 ### Biased polar sampling
@@ -403,7 +403,7 @@ Ref:
 
 - [Incremental Sampling-based Algorithms for Optimal Motion Planning](https://arxiv.org/abs/1005.0416)
 
-- [Sampling-based Algorithms for Optimal Motion Planning](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.419.5503&rep=rep1&type=pdf)
+- [Sampling-based Algorithms for Optimal Motion Planning](https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=bddbc99f97173430aa49a0ada53ab5bade5902fa)
 
 ### RRT\* with reeds-shepp path
 
@@ -421,7 +421,7 @@ A double integrator motion model is used for LQR local planner.
 
 Ref:
 
-- [LQR\-RRT\*: Optimal Sampling\-Based Motion Planning with Automatically Derived Extension Heuristics](http://lis.csail.mit.edu/pubs/perez-icra12.pdf)
+- [LQR\-RRT\*: Optimal Sampling\-Based Motion Planning with Automatically Derived Extension Heuristics](https://lis.csail.mit.edu/pubs/perez-icra12.pdf)
 
 - [MahanFathi/LQR\-RRTstar: LQR\-RRT\* method is used for random motion planning of a simple pendulum in its phase plot](https://github.com/MahanFathi/LQR-RRTstar)
 
@@ -436,7 +436,7 @@ It can calculate a 2D path, velocity, and acceleration profile based on quintic 
 
 Ref:
 
-- [Local Path Planning And Motion Control For Agv In Positioning](http://ieeexplore.ieee.org/document/637936/)
+- [Local Path Planning And Motion Control For Agv In Positioning](https://ieeexplore.ieee.org/document/637936/)
 
 ## Reeds Shepp planning
 
@@ -523,7 +523,7 @@ Path tracking simulation with LQR speed and steering control.
 
 Ref:
 
-- [Towards fully autonomous driving: Systems and algorithms \- IEEE Conference Publication](http://ieeexplore.ieee.org/document/5940562/)
+- [Towards fully autonomous driving: Systems and algorithms \- IEEE Conference Publication](https://ieeexplore.ieee.org/document/5940562/)
 
 
 ## Model predictive speed and steering control
@@ -630,7 +630,7 @@ If you or your company would like to support this project, please consider:
 
 - [Become a backer or sponsor on Patreon](https://www.patreon.com/myenigma)
 
-- [One-time donation via PayPal](https://www.paypal.me/myenigmapay/)
+- [One-time donation via PayPal](https://www.paypal.com/paypalme/myenigmapay/)
 
 If you would like to support us in some other way, please contact with creating an issue.
 
@@ -640,7 +640,7 @@ If you would like to support us in some other way, please contact with creating 
 
 They are providing a free license of their IDEs for this OSS development.   
 
-### [1Password](https://github.com/1Password/1password-teams-open-source)
+### [1Password](https://github.com/1Password/for-open-source)
 
 They are providing a free license of their 1Password team license for this OSS project.   
 

--- a/SLAM/GraphBasedSLAM/data/README.rst
+++ b/SLAM/GraphBasedSLAM/data/README.rst
@@ -3,4 +3,4 @@ Acknowledgments and References
 
 Thanks to Luca Larlone for allowing inclusion of the `Intel dataset <https://lucacarlone.mit.edu/datasets/>`_ in this repo.
 
-1. Carlone, L. and Censi, A., 2014. `From angular manifolds to the integer lattice: Guaranteed orientation estimation with application to pose graph optimization <https://arxiv.org/pdf/1211.3063.pdf>`_. IEEE Transactions on Robotics, 30(2), pp.475-492.
+1. Carlone, L. and Censi, A., 2014. `From angular manifolds to the integer lattice: Guaranteed orientation estimation with application to pose graph optimization <https://arxiv.org/pdf/1211.3063>`_. IEEE Transactions on Robotics, 30(2), pp.475-492.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ environment:
   global:
     # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
     # /E:ON and /V:ON options are not enabled in the batch script intepreter
-    # See: http://stackoverflow.com/a/13751649/163740
+    # See: https://stackoverflow.com/a/13751649/163740
     CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_env.cmd"
 
   matrix:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,7 +3,7 @@
 #
 # This file does only contain a selection of the most common options. For a
 # full list see the documentation:
-# http://www.sphinx-doc.org/en/master/config
+# https://www.sphinx-doc.org/en/master/config
 
 # -- Path setup --------------------------------------------------------------
 

--- a/docs/getting_started_main.rst
+++ b/docs/getting_started_main.rst
@@ -49,7 +49,7 @@ For development:
 .. _`pytest-xdist`: https://github.com/pytest-dev/pytest-xdist
 .. _`mypy`: https://mypy-lang.org/
 .. _`sphinx`: https://www.sphinx-doc.org/en/master/index.html
-.. _`ruff`: https://github.com/charliermarsh/ruff
+.. _`ruff`: https://github.com/astral-sh/ruff
 
 
 How to use

--- a/docs/how_to_contribute_main.rst
+++ b/docs/how_to_contribute_main.rst
@@ -159,6 +159,6 @@ Sponsors
 .. _`JetBrains`: https://www.jetbrains.com/
 .. _`Sponsor @AtsushiSakai on GitHub Sponsors`: https://github.com/sponsors/AtsushiSakai
 .. _`Become a backer or sponsor on Patreon`: https://www.patreon.com/myenigma
-.. _`One-time donation via PayPal`: https://www.paypal.me/myenigmapay/
+.. _`One-time donation via PayPal`: https://www.paypal.com/paypalme/myenigmapay/
 
 

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -22,7 +22,7 @@ if errorlevel 9009 (
 	echo.may add the Sphinx directory to PATH.
 	echo.
 	echo.If you don't have Sphinx installed, grab it from
-	echo.http://sphinx-doc.org/
+	echo.https://sphinx-doc.org/
 	exit /b 1
 )
 

--- a/docs/modules/localization/particle_filter_localization/particle_filter_localization_main.rst
+++ b/docs/modules/localization/particle_filter_localization/particle_filter_localization_main.rst
@@ -34,4 +34,4 @@ References:
 ~~~~~~~~~~~
 
 - `_PROBABILISTIC ROBOTICS: <http://www.probabilistic-robotics.org>`_
-- `Improving the particle filter in high dimensions using conjugate artificial process noise <https://arxiv.org/pdf/1801.07000.pdf>`_
+- `Improving the particle filter in high dimensions using conjugate artificial process noise <https://arxiv.org/pdf/1801.07000>`_

--- a/docs/modules/mapping/rectangle_fitting/rectangle_fitting_main.rst
+++ b/docs/modules/mapping/rectangle_fitting/rectangle_fitting_main.rst
@@ -7,7 +7,7 @@ This is an object shape recognition using rectangle fitting.
 
 This example code is based on this paper algorithm:
 
-- `Efficient L\-Shape Fitting for Vehicle Detection Using Laser Scanners \- The Robotics Institute Carnegie Mellon University <https://www.ri.cmu.edu/publications/efficient-l-shape-fitting-for-vehicle-detection-using-laser-scanners>`_
+- `Efficient L\-Shape Fitting for Vehicle Detection Using Laser Scanners \- The Robotics Institute Carnegie Mellon University <https://www.ri.cmu.edu/publications/efficient-l-shape-fitting-for-vehicle-detection-using-laser-scanners/>`_
 
 The algorithm consists of 2 steps as below.
 
@@ -66,4 +66,4 @@ API
 References
 ~~~~~~~~~~
 
-- `Efficient L\-Shape Fitting for Vehicle Detection Using Laser Scanners \- The Robotics Institute Carnegie Mellon University <https://www.ri.cmu.edu/publications/efficient-l-shape-fitting-for-vehicle-detection-using-laser-scanners>`_
+- `Efficient L\-Shape Fitting for Vehicle Detection Using Laser Scanners \- The Robotics Institute Carnegie Mellon University <https://www.ri.cmu.edu/publications/efficient-l-shape-fitting-for-vehicle-detection-using-laser-scanners/>`_

--- a/docs/modules/path_planning/bezier_path/bezier_path_main.rst
+++ b/docs/modules/path_planning/bezier_path/bezier_path_main.rst
@@ -17,4 +17,4 @@ Ref:
 
 -  `Continuous Curvature Path Generation Based on Bezier Curves for
    Autonomous
-   Vehicles <http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.294.6438&rep=rep1&type=pdf>`__
+   Vehicles <https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=b00b657c3e0e828c589132a14825e7119772003d>`

--- a/docs/modules/path_planning/bugplanner/bugplanner_main.rst
+++ b/docs/modules/path_planning/bugplanner/bugplanner_main.rst
@@ -5,4 +5,4 @@ This is a 2D planning with Bug algorithm.
 
 .. image:: https://github.com/AtsushiSakai/PythonRoboticsGifs/raw/master/PathPlanning/BugPlanner/animation.gif
 
-- `ECE452 Bug Algorithms <https://sites.google.com/site/ece452bugalgorithms/>`_
+- `ECE452 Bug Algorithms <https://web.archive.org/web/20201103052224/https://sites.google.com/site/ece452bugalgorithms/>`_

--- a/docs/modules/path_planning/coverage_path/coverage_path_main.rst
+++ b/docs/modules/path_planning/coverage_path/coverage_path_main.rst
@@ -29,6 +29,6 @@ This is a 2D grid based wavefront coverage path planner simulation:
 .. image:: https://github.com/AtsushiSakai/PythonRoboticsGifs/raw/master/PathPlanning/WavefrontCPP/animation2.gif
 .. image:: https://github.com/AtsushiSakai/PythonRoboticsGifs/raw/master/PathPlanning/WavefrontCPP/animation3.gif
 
-- `Planning paths of complete coverage of an unstructured environment by a mobile robot <http://pinkwink.kr/attachment/cfile3.uf@1354654A4E8945BD13FE77.pdf>`_
+- `Planning paths of complete coverage of an unstructured environment by a mobile robot <https://pinkwink.kr/attachment/cfile3.uf@1354654A4E8945BD13FE77.pdf>`_
 
 

--- a/docs/modules/path_planning/dubins_path/dubins_path_main.rst
+++ b/docs/modules/path_planning/dubins_path/dubins_path_main.rst
@@ -72,5 +72,5 @@ Reference
 ~~~~~~~~~~~~~~~~~~~~
 -  `On Curves of Minimal Length with a Constraint on Average Curvature, and with Prescribed Initial and Terminal Positions and Tangents <https://www.jstor.org/stable/2372560?origin=crossref>`__
 -  `Dubins path - Wikipedia <https://en.wikipedia.org/wiki/Dubins_path>`__
--  `15.3.1 Dubins Curves <http://planning.cs.uiuc.edu/node821.html>`__
+-  `15.3.1 Dubins Curves <https://lavalle.pl/planning/node821.html>`__
 -  `A Comprehensive, Step-by-Step Tutorial to Computing Dubin’s Paths <https://gieseanw.wordpress.com/2012/10/21/a-comprehensive-step-by-step-tutorial-to-computing-dubins-paths/>`__

--- a/docs/modules/path_planning/model_predictive_trajectory_generator/model_predictive_trajectory_generator_main.rst
+++ b/docs/modules/path_planning/model_predictive_trajectory_generator/model_predictive_trajectory_generator_main.rst
@@ -19,4 +19,4 @@ Lookup table generation sample
 Ref:
 
 -  `Optimal rough terrain trajectory generation for wheeled mobile
-   robots <http://journals.sagepub.com/doi/pdf/10.1177/0278364906075328>`__
+   robots <https://journals.sagepub.com/doi/pdf/10.1177/0278364906075328>`__

--- a/docs/modules/path_planning/quintic_polynomials_planner/quintic_polynomials_planner_main.rst
+++ b/docs/modules/path_planning/quintic_polynomials_planner/quintic_polynomials_planner_main.rst
@@ -101,6 +101,6 @@ References:
 ~~~~~~~~~~~
 
 -  `Local Path Planning And Motion Control For Agv In
-   Positioning <http://ieeexplore.ieee.org/document/637936/>`__
+   Positioning <https://ieeexplore.ieee.org/document/637936/>`__
 
 

--- a/docs/modules/path_planning/reeds_shepp_path/reeds_shepp_path_main.rst
+++ b/docs/modules/path_planning/reeds_shepp_path/reeds_shepp_path_main.rst
@@ -383,7 +383,7 @@ Hence, we have:
 Ref:
 
 -  `15.3.2 Reeds-Shepp
-   Curves <http://planning.cs.uiuc.edu/node822.html>`__
+   Curves <https://lavalle.pl/planning/node822.html>`__
 
 -  `optimal paths for a car that goes both forwards and
    backwards <https://pdfs.semanticscholar.org/932e/c495b1d0018fd59dee12a0bf74434fac7af4.pdf>`__

--- a/docs/modules/path_planning/rrt/rrt_main.rst
+++ b/docs/modules/path_planning/rrt/rrt_main.rst
@@ -57,7 +57,7 @@ Ref:
 
 -  `Informed RRT\*: Optimal Sampling-based Path Planning Focused via
    Direct Sampling of an Admissible Ellipsoidal
-   Heuristic <https://arxiv.org/pdf/1404.2334.pdf>`__
+   Heuristic <https://arxiv.org/pdf/1404.2334>`__
 
 .. _batch-informed-rrt*:
 
@@ -90,10 +90,10 @@ PID is used for speed control.
 Ref:
 
 -  `Motion Planning in Complex Environments using Closed-loop
-   Prediction <http://acl.mit.edu/papers/KuwataGNC08.pdf>`__
+   Prediction <https://acl.mit.edu/papers/KuwataGNC08.pdf>`__
 
 -  `Real-time Motion Planning with Applications to Autonomous Urban
-   Driving <http://acl.mit.edu/papers/KuwataTCST09.pdf>`__
+   Driving <https://acl.mit.edu/papers/KuwataTCST09.pdf>`__
 
 -  `[1601.06326] Sampling-based Algorithms for Optimal Motion Planning
    Using Closed-loop Prediction <https://arxiv.org/abs/1601.06326>`__
@@ -113,6 +113,6 @@ Ref:
 
 -  `LQR-RRT\*: Optimal Sampling-Based Motion Planning with Automatically
    Derived Extension
-   Heuristics <http://lis.csail.mit.edu/pubs/perez-icra12.pdf>`__
+   Heuristics <https://lis.csail.mit.edu/pubs/perez-icra12.pdf>`__
 
 -  `MahanFathi/LQR-RRTstar: LQR-RRT\* method is used for random motion planning of a simple pendulum in its phase plot <https://github.com/MahanFathi/LQR-RRTstar>`__

--- a/docs/modules/path_planning/rrt/rrt_star.rst
+++ b/docs/modules/path_planning/rrt/rrt_star.rst
@@ -16,6 +16,6 @@ Simulation
 
 Ref
 ^^^
--  `Sampling-based Algorithms for Optimal Motion Planning <https://arxiv.org/pdf/1105.1186.pdf>`__
+-  `Sampling-based Algorithms for Optimal Motion Planning <https://arxiv.org/pdf/1105.1186>`__
 -  `Incremental Sampling-based Algorithms for Optimal Motion Planning <https://arxiv.org/abs/1005.0416>`__
 

--- a/docs/modules/path_planning/state_lattice_planner/state_lattice_planner_main.rst
+++ b/docs/modules/path_planning/state_lattice_planner/state_lattice_planner_main.rst
@@ -25,9 +25,9 @@ Lane sampling
 Ref:
 
 -  `Optimal rough terrain trajectory generation for wheeled mobile
-   robots <http://journals.sagepub.com/doi/pdf/10.1177/0278364906075328>`__
+   robots <https://journals.sagepub.com/doi/pdf/10.1177/0278364906075328>`__
 
 -  `State Space Sampling of Feasible Motions for High-Performance Mobile
    Robot Navigation in Complex
-   Environments <http://www.frc.ri.cmu.edu/~alonzo/pubs/papers/JFR_08_SS_Sampling.pdf>`__
+   Environments <https://www.frc.ri.cmu.edu/~alonzo/pubs/papers/JFR_08_SS_Sampling.pdf>`__
 

--- a/docs/modules/path_tracking/cgmres_nmpc/cgmres_nmpc_main.rst
+++ b/docs/modules/path_tracking/cgmres_nmpc/cgmres_nmpc_main.rst
@@ -60,7 +60,7 @@ Ref
 
 -  `Shunichi09/nonlinear_control: Implementing the nonlinear model
    predictive control, sliding mode
-   control <https://github.com/Shunichi09/nonlinear_control>`__
+   control <https://github.com/Shunichi09/PythonLinearNonlinearControl>`__
 
 -  `非線形モデル予測制御におけるCGMRES法をpythonで実装する -
    Qiita <https://qiita.com/MENDY/items/4108190a579395053924>`__

--- a/docs/modules/path_tracking/lqr_speed_and_steering_control/lqr_speed_and_steering_control_main.rst
+++ b/docs/modules/path_tracking/lqr_speed_and_steering_control/lqr_speed_and_steering_control_main.rst
@@ -137,4 +137,4 @@ Simulation results
 References:
 ~~~~~~~~~~~
 
--  `Towards fully autonomous driving: Systems and algorithms <http://ieeexplore.ieee.org/document/5940562/>`__
+-  `Towards fully autonomous driving: Systems and algorithms <https://ieeexplore.ieee.org/document/5940562/>`__

--- a/docs/modules/path_tracking/model_predictive_speed_and_steering_control/model_predictive_speed_and_steering_control_main.rst
+++ b/docs/modules/path_tracking/model_predictive_speed_and_steering_control/model_predictive_speed_and_steering_control_main.rst
@@ -133,5 +133,5 @@ Reference
 -  `Vehicle Dynamics and Control \| Rajesh Rajamani \|
    Springer <http://www.springer.com/us/book/9781461414322>`__
 
--  `MPC Course Material - MPC Lab @
-   UC-Berkeley <http://www.mpc.berkeley.edu/mpc-course-material/>`__
+-  `MPC Book - MPC Lab @
+   UC-Berkeley <https://sites.google.com/berkeley.edu/mpc-lab/mpc-course-material>`__

--- a/docs/modules/path_tracking/model_predictive_speed_and_steering_control/model_predictive_speed_and_steering_control_main.rst
+++ b/docs/modules/path_tracking/model_predictive_speed_and_steering_control/model_predictive_speed_and_steering_control_main.rst
@@ -134,4 +134,4 @@ Reference
    Springer <http://www.springer.com/us/book/9781461414322>`__
 
 -  `MPC Course Material - MPC Lab @
-   UC-Berkeley <http://www.mpc.berkeley.edu/mpc-course-material>`__
+   UC-Berkeley <http://www.mpc.berkeley.edu/mpc-course-material/>`__

--- a/users_comments.md
+++ b/users_comments.md
@@ -386,14 +386,14 @@ Dear Atsushi Sakai, <br>Thank you so much for creating PythonRobotics and docume
 1. B. Blaga, M. Deac, R. W. Y. Al-doori, M. Negru and R. Dǎnescu, "Miniature Autonomous Vehicle Development on Raspberry Pi," 2018 IEEE 14th International Conference on Intelligent Computer Communication and Processing (ICCP), Cluj-Napoca, Romania, 2018, pp. 229-236.
 doi: 10.1109/ICCP.2018.8516589
 keywords: {Automobiles;Task analysis;Autonomous vehicles;Path planning;Global Positioning System;Cameras;miniature autonomous vehicle;path planning;navigation;parking assist;lane detection and tracking;traffic sign recognition},
-URL: http://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=8516589&isnumber=8516425
+URL: https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=8516589&isnumber=8516425
 
 2. Peggy (Yuchun) Wang and Caitlin Hogan, "Path Planning with Dynamic Obstacle Avoidance for a Jumping-Enabled Robot", AA228/CS238 class report, Department of Computer Science, Stanford University, URL: https://web.stanford.edu/class/aa228/reports/2018/final113.pdf
 
-3. Welburn, E, Hakim Khalili, H, Gupta, A, Watson, S & Carrasco, J 2019, A Navigational System for Quadcopter Remote Inspection of Offshore Substations. in The Fifteenth International Conference on Autonomic and Autonomous Systems 2019. URL:https://www.research.manchester.ac.uk/portal/files/107169964/ICAS19_A_Navigational_System_for_Quadcopter_Remote_Inspection_of_Offshore_Substations.pdf
+3. Welburn, E, Hakim Khalili, H, Gupta, A, Watson, S & Carrasco, J 2019, A Navigational System for Quadcopter Remote Inspection of Offshore Substations. in The Fifteenth International Conference on Autonomic and Autonomous Systems 2019. URL:https://research.manchester.ac.uk/portal/files/107169964/ICAS19_A_Navigational_System_for_Quadcopter_Remote_Inspection_of_Offshore_Substations.pdf
 
 4. E. Horváth, C. Hajdu, C. Radu and Á. Ballagi, "Range Sensor-based Occupancy Grid Mapping with Signatures," 2019 20th International Carpathian Control Conference (ICCC), Krakow-Wieliczka, Poland, 2019, pp. 1-5.
-URL: http://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=8765684&isnumber=8765679
+URL: https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=8765684&isnumber=8765679
 
 5. Josie Hughes, Masaru Shimizu, and Arnoud Visser, "A Review of Robot Rescue Simulation Platforms for Robotics Education"
 URL: https://2019.robocup.org/downloads/program/HughesEtAl2019.pdf
@@ -408,7 +408,7 @@ URL: https://arxiv.org/abs/1910.01557
 URL: https://pdfs.semanticscholar.org/5c06/f3cb9542a51e1bf1a32523c1bc7fea6cecc5.pdf
 
 9. Brijen Thananjeyan, et al. "ABC-LMPC: Safe Sample-Based Learning MPC for Stochastic Nonlinear Dynamical Systems with Adjustable Boundary Conditions"
-URL: https://arxiv.org/pdf/2003.01410.pdf
+URL: https://arxiv.org/pdf/2003.01410
 
 # Others
 

--- a/users_comments.md
+++ b/users_comments.md
@@ -17,13 +17,7 @@ Ref:
 
 # Educational users
 
-This is a list of users who are using PythonRobotics for education.
-
-If you found other users, please make an issue to let me know.
-
-- [CSCI/ARTI 4530/6530: Introduction to Robotics (Fall 2018),  University of Georgia ](http://cobweb.cs.uga.edu/~ramviyas/csci_x530.html)
-
-- [CIT Modules & Programmes \- COMP9073 \- Automation with Python](https://courses.cit.ie/index.cfm/page/module/moduleId/14416)
+If you found users who are using PythonRobotics for education, please make an issue to let me know.
 
 # Stargazers location map
 


### PR DESCRIPTION
#### Reference issue

none

#### What does this implement/fix?

fix dead (HTTP status 40X) or moved (30X) URL links in documents.

#### Additional information
##### Links to new sites found manually
 - The sites not explicitly redirected but convinced to be successors
   1. [original](http://www.mpc.berkeley.edu/mpc-course-material/)-> [new site](https://sites.google.com/berkeley.edu/mpc-lab/mpc-course-material)
   1. [original](http://planning.cs.uiuc.edu/node822.html) -> [new site](https://lavalle.pl/planning/node822.html)
 - new sites not found, then redirected to Wayback Machine because helpful to understand the algorithms
   - https://web.archive.org/web/20200130224918/http://doswa.com/2009/07/13/circle-segment-intersectioncollision.html
   - https://web.archive.org/web/20201103052224/https://sites.google.com/site/ece452bugalgorithms/

##### Links dead but not fixed in this PR
 - The link shows `This repo has been deactivated`, but no way to fix
   - https://codecov.io/gh/AtsushiSakai/PythonRobotics
 - new sites not found but unfixed links because just educational course introductions
   - http://cobweb.cs.uga.edu/~ramviyas/csci_x530.html
   - https://courses.cit.ie/index.cfm/page/module/moduleId/14416

#### CheckList
- [ ] Did you add an unittest for your new example or defect fix?
- [ ] Did you add documents for your new example?
- [ ] All CIs are green? (You can check it after submitting)
