### PR TITLE
Add root directory to system path for lattice planner

### DIFF
--- a/PathPlanning/StateLatticePlanner/state_lattice_planner.py
+++ b/PathPlanning/StateLatticePlanner/state_lattice_planner.py
@@ -22,7 +22,9 @@ from matplotlib import pyplot as plt
 import numpy as np
 import math
 import pathlib
+
 sys.path.append(str(pathlib.Path(__file__).parent.parent))
+sys.path.append(str(pathlib.Path(__file__).parent.parent.parent))
 
 import ModelPredictiveTrajectoryGenerator.trajectory_generator as planner
 import ModelPredictiveTrajectoryGenerator.motion_model as motion_model


### PR DESCRIPTION
#### Reference issue
Couldn't run lattice_planner.py because it was giving module not found error.

#### What does this implement/fix?
It adds the root of the directory to the sys.path so that eliminates the module not found error.

#### CheckList
- [ ] Did you add an unittest for your new example or defect fix?
- [ ] Did you add documents for your new example?
- [x] All CIs are green? (You can check it after submitting)
