### PR TITLE
Fix/path smoothing robot radius

### DIFF
--- a/tests/test_rrt_with_pathsmoothing_radius.py
+++ b/tests/test_rrt_with_pathsmoothing_radius.py
@@ -1,0 +1,48 @@
+import conftest
+import math
+
+from PathPlanning.RRT import rrt_with_pathsmoothing as rrt_module
+
+def test_smoothed_path_safety():
+    # Define test environment
+    obstacle_list = [
+        (5, 5, 1.0),
+        (3, 6, 2.0),
+        (3, 8, 2.0),
+        (3, 10, 2.0),
+        (7, 5, 2.0),
+        (9, 5, 2.0)
+    ]
+    robot_radius = 0.5
+
+    # Disable animation for testing
+    rrt_module.show_animation = False
+
+    # Create RRT planner
+    rrt = rrt_module.RRT(
+        start=[0, 0],
+        goal=[6, 10],
+        rand_area=[-2, 15],
+        obstacle_list=obstacle_list,
+        robot_radius=robot_radius
+    )
+
+    # Run RRT
+    path = rrt.planning(animation=False)
+
+    # Smooth the path
+    smoothed = rrt_module.path_smoothing(path, max_iter=1000,
+                                         obstacle_list=obstacle_list,
+                                         robot_radius=robot_radius)
+
+    # Check if all points on the smoothed path are safely distant from obstacles
+    for x, y in smoothed:
+        for ox, oy, obs_radius in obstacle_list:
+            d = math.hypot(x - ox, y - oy)
+            min_safe_dist = obs_radius + robot_radius
+            assert d > min_safe_dist, \
+                f"Point ({x:.2f}, {y:.2f}) too close to obstacle at ({ox}, {oy})"
+
+
+if __name__ == '__main__':
+    conftest.run_this_test(__file__)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! 
Please check this document before submitting:
- [How to contribute](https://atsushisakai.github.io/PythonRobotics/modules/0_getting_started/3_how_to_contribute.html#adding-a-new-algorithm-example)

Note that this is my hobby project; I appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
- fix #1230 
Fixes path smoothing safety issue discussed in #1230 

#### What does this implement/fix?
This PR fixes an issue in the `path_smoothing()` function, where the collision checking via `line_collision_check()` did not take `robot_radius` into account correctly. This caused the smoothed path to pass dangerously close to obstacles.

- Modified `line_collision_check()` to check collision along finite-length line segments and incorporate `robot_radius`.
- Updated `path_smoothing()` logic to use this corrected check.
- Added a new unit test to verify that smoothed paths maintain clearance from obstacles based on robot radius.

#### Additional information
- Confirmed original vs smoothed paths via animation and test assertions.

#### CheckList
- [x] Did you add an unittest for your new example or defect fix?
- [ ] Did you add documents for your new example?  N/A (not a new algorithm)
- [x] All CIs are green? (You can check it after submitting)
