### PR TITLE
Potential fix for code scanning alert no. 328: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,8 @@ on:
   schedule:
     - cron: '0 19 * * 0'
 
+permissions:
+  contents: read
 jobs:
   CodeQL-Build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/AtsushiSakai/PythonRobotics/security/code-scanning/328](https://github.com/AtsushiSakai/PythonRobotics/security/code-scanning/328)

To address the issue, add a `permissions` block to the workflow that restricts the GITHUB_TOKEN permissions. Since the job does not appear to require write access—common for CodeQL workflows—the most minimal safe configuration is `contents: read`. This limits token usage to only reading repository contents, minimizing possible damage from any workflow compromise. Apply this change at the workflow root (before the `jobs:` block) to apply to all jobs that don't have their own `permissions` keys. If additional permissions were required for specific jobs, those could be set within that job's block, but that's not needed here.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
