### PR TITLE
Fix unit mismatch in Dijkstra calc_index

### DIFF
--- a/PathPlanning/Dijkstra/dijkstra.py
+++ b/PathPlanning/Dijkstra/dijkstra.py
@@ -143,7 +143,7 @@ class DijkstraPlanner:
         return round((position - minp) / self.resolution)
 
     def calc_index(self, node):
-        return (node.y - self.min_y) * self.x_width + (node.x - self.min_x)
+        return node.y * self.x_width + node.x
 
     def verify_node(self, node):
         px = self.calc_position(node.x, self.min_x)


### PR DESCRIPTION
## Summary

- Fixes #1318
- Removes the subtraction of meter-unit `self.min_x`/`self.min_y` from grid-index values `node.x`/`node.y` in `calc_index`

## What changed

`PathPlanning/Dijkstra/dijkstra.py`, `calc_index` method:

```python
# Before (mixes grid indices with meter-unit min values)
return (node.y - self.min_y) * self.x_width + (node.x - self.min_x)

# After (uses grid indices only)
return node.y * self.x_width + node.x
```

`node.x` and `node.y` are already grid indices (computed via `calc_xy_index` which divides by resolution). Subtracting `self.min_x`/`self.min_y` (in meters) is a unit mismatch. The algorithm produced correct results because the offset was constant across all nodes, preserving dictionary key uniqueness, but the formula was conceptually wrong.

## Test plan

- [ ] Existing Dijkstra tests pass
- [ ] Path output is identical (the index offset was constant, so behavior is unchanged)