### PR TITLE
stop rejecting grid index 0 in set_value_from_xy_pos and set_value_from_xy_index

### DIFF
--- a/Mapping/grid_map_lib/grid_map_lib.py
+++ b/Mapping/grid_map_lib/grid_map_lib.py
@@ -100,7 +100,7 @@ class GridMap:
 
         x_ind, y_ind = self.get_xy_index_from_xy_pos(x_pos, y_pos)
 
-        if (not x_ind) or (not y_ind):
+        if (x_ind is None) or (y_ind is None):
             return False  # NG
 
         flag = self.set_value_from_xy_index(x_ind, y_ind, val)
@@ -118,7 +118,7 @@ class GridMap:
         """
 
         if (x_ind is None) or (y_ind is None):
-            return False, False
+            return False
 
         grid_ind = int(y_ind * self.width + x_ind)
 

--- a/tests/test_grid_map_lib.py
+++ b/tests/test_grid_map_lib.py
@@ -1,4 +1,4 @@
-from Mapping.grid_map_lib.grid_map_lib import GridMap
+from Mapping.grid_map_lib.grid_map_lib import GridMap, FloatGrid
 import conftest
 import numpy as np
 
@@ -34,6 +34,23 @@ def test_xy_and_grid_index_conversion():
             x_ind_2, y_ind_2 = grid_map.calc_xy_index_from_grid_index(grid_ind)
             assert x_ind == x_ind_2
             assert y_ind == y_ind_2
+
+
+def test_set_xy_pos_at_origin_index():
+    # Regression: the guard used to be `if (not x_ind) or (not y_ind):`
+    # which rejected the valid grid index 0 (since `not 0` is True in
+    # Python). Setting a value at the (0, 0) cell must succeed and the
+    # return value must be a plain `True` (not the tuple `(False, False)`
+    # that the previous None-guard returned).
+    grid_map = GridMap(4, 4, 1.0, 2.0, 2.0)  # left_lower = (0, 0)
+    ok = grid_map.set_value_from_xy_index(0, 0, FloatGrid(0.5))
+    assert ok is True
+    assert grid_map.data[0].get_float_data() == 0.5
+
+    # And the higher-level pos API should accept the (0, 0) cell.
+    ok = grid_map.set_value_from_xy_pos(0.5, 0.5, FloatGrid(0.7))
+    assert ok is True
+    assert grid_map.data[0].get_float_data() == 0.7
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
GridMap.set_value_from_xy_pos used `if (not x_ind) or (not y_ind):` to bail out for out-of-bounds coordinates, but `not 0` is `True` in Python, so the valid grid index 0 was always rejected. The same guard in set_value_from_xy_index also returned `return False, False` (a 2-tuple) from the None-guard branch while the other branches returned a plain bool, so any caller that did `flag = set_value_from_xy_index(...); if flag: ...` would silently get `False` from `if (False, False):` for an out-of-bounds call (which is what we want), but more importantly the `set_value_from_xy_pos` wrapper was throwing away values at index 0.

Swapped both guards to `if (x_ind is None) or (y_ind is None):`, made set_value_from_xy_index's None-branch return a plain `False` to match the other branches, and added a regression test in tests/test_grid_map_lib.py that sets a value at (0, 0) and confirms it lands in `grid_map.data[0]`.