### PR TITLE
Fix RRT obstacle circle scaling on figure resize

### DIFF
--- a/PathPlanning/BatchInformedRRTStar/batch_informed_rrt_star.py
+++ b/PathPlanning/BatchInformedRRTStar/batch_informed_rrt_star.py
@@ -15,10 +15,16 @@ Reference: https://arxiv.org/abs/1405.5848
 """
 
 import math
+import pathlib
 import random
+import sys
 
 import matplotlib.pyplot as plt
 import numpy as np
+
+sys.path.append(str(pathlib.Path(__file__).parent.parent.parent))
+
+from utils.plot import plot_circle
 
 show_animation = True
 
@@ -579,7 +585,7 @@ class BITStar:
             plt.plot([start[0], start[1]], [end[0], end[1]], "-g")
 
         for (ox, oy, size) in self.obstacleList:
-            plt.plot(ox, oy, "ok", ms=30 * size)
+            plot_circle(ox, oy, size)
 
         plt.plot(self.start[0], self.start[1], "xr")
         plt.plot(self.goal[0], self.goal[1], "xr")

--- a/PathPlanning/InformedRRTStar/informed_rrt_star.py
+++ b/PathPlanning/InformedRRTStar/informed_rrt_star.py
@@ -22,6 +22,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from utils.angle import rot_mat_2d
+from utils.plot import plot_circle
 
 show_animation = True
 
@@ -289,7 +290,7 @@ class InformedRRTStar:
                              [node.y, self.node_list[node.parent].y], "-g")
 
         for (ox, oy, size) in self.obstacle_list:
-            plt.plot(ox, oy, "ok", ms=30 * size)
+            plot_circle(ox, oy, size)
 
         plt.plot(self.start.x, self.start.y, "xr")
         plt.plot(self.goal.x, self.goal.y, "xr")

--- a/PathPlanning/LQRRRTStar/lqr_rrt_star.py
+++ b/PathPlanning/LQRRRTStar/lqr_rrt_star.py
@@ -13,9 +13,11 @@ import numpy as np
 import sys
 import pathlib
 sys.path.append(str(pathlib.Path(__file__).parent.parent))
+sys.path.append(str(pathlib.Path(__file__).parent.parent.parent))
 
 from LQRPlanner.lqr_planner import LQRPlanner
 from RRTStar.rrt_star import RRTStar
+from utils.plot import plot_circle
 
 show_animation = True
 
@@ -110,7 +112,7 @@ class LQRRRTStar(RRTStar):
                 plt.plot(node.path_x, node.path_y, "-g")
 
         for (ox, oy, size) in self.obstacle_list:
-            plt.plot(ox, oy, "ok", ms=30 * size)
+            plot_circle(ox, oy, size)
 
         plt.plot(self.start.x, self.start.y, "xr")
         plt.plot(self.end.x, self.end.y, "xr")

--- a/PathPlanning/RRTDubins/rrt_dubins.py
+++ b/PathPlanning/RRTDubins/rrt_dubins.py
@@ -16,7 +16,7 @@ sys.path.append(str(pathlib.Path(__file__).parent.parent))
 
 from RRT.rrt import RRT
 from DubinsPath import dubins_path_planner
-from utils.plot import plot_arrow
+from utils.plot import plot_arrow, plot_circle
 
 show_animation = True
 
@@ -114,7 +114,7 @@ class RRTDubins(RRT):
                 plt.plot(node.path_x, node.path_y, "-g")
 
         for (ox, oy, size) in self.obstacle_list:
-            plt.plot(ox, oy, "ok", ms=30 * size)
+            plot_circle(ox, oy, size)
 
         plt.plot(self.start.x, self.start.y, "xr")
         plt.plot(self.end.x, self.end.y, "xr")

--- a/PathPlanning/RRTStarDubins/rrt_star_dubins.py
+++ b/PathPlanning/RRTStarDubins/rrt_star_dubins.py
@@ -16,7 +16,7 @@ sys.path.append(str(pathlib.Path(__file__).parent.parent))
 
 from DubinsPath import dubins_path_planner
 from RRTStar.rrt_star import RRTStar
-from utils.plot import plot_arrow
+from utils.plot import plot_arrow, plot_circle
 
 show_animation = True
 
@@ -119,7 +119,7 @@ class RRTStarDubins(RRTStar):
                 plt.plot(node.path_x, node.path_y, "-g")
 
         for (ox, oy, size) in self.obstacle_list:
-            plt.plot(ox, oy, "ok", ms=30 * size)
+            plot_circle(ox, oy, size)
 
         plt.plot(self.start.x, self.start.y, "xr")
         plt.plot(self.end.x, self.end.y, "xr")

--- a/PathPlanning/RRTStarReedsShepp/rrt_star_reeds_shepp.py
+++ b/PathPlanning/RRTStarReedsShepp/rrt_star_reeds_shepp.py
@@ -13,9 +13,11 @@ import pathlib
 import matplotlib.pyplot as plt
 import numpy as np
 sys.path.append(str(pathlib.Path(__file__).parent.parent))
+sys.path.append(str(pathlib.Path(__file__).parent.parent.parent))
 
 from ReedsSheppPath import reeds_shepp_path_planning
 from RRTStar.rrt_star import RRTStar
+from utils.plot import plot_circle
 
 show_animation = True
 
@@ -133,7 +135,7 @@ class RRTStarReedsShepp(RRTStar):
                 plt.plot(node.path_x, node.path_y, "-g")
 
         for (ox, oy, size) in self.obstacle_list:
-            plt.plot(ox, oy, "ok", ms=30 * size)
+            plot_circle(ox, oy, size)
 
         plt.plot(self.start.x, self.start.y, "xr")
         plt.plot(self.end.x, self.end.y, "xr")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,9 @@
 import conftest  # Add root path to sys.path
-from utils import angle
+import matplotlib.pyplot as plt
 from numpy.testing import assert_allclose
 import numpy as np
+
+from utils import angle, plot
 
 
 def test_rot_mat_2d():
@@ -21,6 +23,36 @@ def test_angle_mod():
 
     assert_allclose(angle.angle_mod(-60.0, zero_2_2pi=True, degree=True),
                     [300.])
+
+
+def test_plot_circle_uses_data_coordinates():
+    figure, axes = plt.subplots()
+
+    circle = plot.plot_circle(2.0, -1.0, 0.75, ax=axes)
+
+    expected_bounds = [1.25, -1.75, 2.75, -0.25]
+    assert circle in axes.patches
+    assert axes.get_aspect() == 1.0
+    assert axes.get_adjustable() == "box"
+
+    figure.canvas.draw()
+    bounds = circle.get_window_extent()
+    assert_allclose(bounds.width, bounds.height)
+    assert_allclose(
+        bounds.transformed(axes.transData.inverted()).extents,
+        expected_bounds,
+    )
+
+    figure.set_size_inches(12.0, 3.0)
+    figure.canvas.draw()
+    resized_bounds = circle.get_window_extent()
+    assert_allclose(resized_bounds.width, resized_bounds.height)
+    assert_allclose(
+        resized_bounds.transformed(axes.transData.inverted()).extents,
+        expected_bounds,
+    )
+
+    plt.close(figure)
 
 
 if __name__ == '__main__':

--- a/utils/plot.py
+++ b/utils/plot.py
@@ -5,11 +5,22 @@ import math
 import matplotlib.pyplot as plt
 import numpy as np
 from mpl_toolkits.mplot3d import art3d
-from matplotlib.patches import FancyArrowPatch
+from matplotlib.patches import Circle, FancyArrowPatch
 from mpl_toolkits.mplot3d.proj3d import proj_transform
 from mpl_toolkits.mplot3d import Axes3D
 
 from utils.angle import rot_mat_2d
+
+
+def plot_circle(x, y, radius, color="k", fill=True, ax=None, **kwargs):
+    """Plot a circle whose center and radius use axes data coordinates."""
+    if ax is None:
+        ax = plt.gca()
+
+    circle = Circle((x, y), radius, color=color, fill=fill, **kwargs)
+    ax.add_patch(circle)
+    ax.set_aspect("equal", adjustable="box")
+    return circle
 
 
 def plot_covariance_ellipse(x, y, cov, chi2=3.0, color="-r", ax=None):


### PR DESCRIPTION
#### Reference issue

Fixes #1396

#### What does this implement/fix?

Six RRT-family visualizations currently draw circular obstacles with a Matplotlib marker whose size is measured in screen points. Resizing the figure therefore changes the marker's radius relative to the planner's data coordinates, even though the obstacle radius used for collision checks has not changed.

This change adds a shared `plot_circle` utility that:

- creates a `Circle` patch with its center and radius in axes data coordinates;
- keeps an equal axes aspect while preserving the configured data limits;
- returns the patch so its geometry can be inspected or customized.

The six affected RRT visualizations now use that helper instead of `ms=30 * size` markers.

#### Additional information

The regression test renders the same radius before and after changing the figure from its default size to 12 by 3 inches. In both cases it verifies that the rendered obstacle is circular and that mapping its bounds back to data coordinates produces the unchanged expected radius.

Local verification with Python 3.13.11:

- `python -m pytest tests -q -Werror` — 138 passed
- `ruff check` on all eight changed Python files — passed
- standalone import checks for all six changed planner scripts from outside the repository cwd — passed

AI-assisted analysis was used to trace all instances of the screen-space marker pattern and prepare the initial implementation and test. I reviewed the final diff and verified it with the repository's complete warning-as-error test suite.

#### CheckList

- [x] Did you add an unittest for your new example or defect fix?
- [x] Did you add documents for your new example? (Not applicable: this fixes existing visualizations and adds no new algorithm.)
- [ ] All CIs are green? (Pending the upstream CI run.)
