### PR TITLE
Run CI on Python 3.14 as well as 3.13

### DIFF
--- a/.github/workflows/Linux_CI.yml
+++ b/.github/workflows/Linux_CI.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.13' ]
+        python-version: [ '3.13', '3.14' ]
 
     name: Python ${{ matrix.python-version }} CI
 

--- a/.github/workflows/MacOS_CI.yml
+++ b/.github/workflows/MacOS_CI.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: [ '3.13' ]
+        python-version: [ '3.13', '3.14' ]
     name: Python ${{ matrix.python-version }} CI
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/Windows_CI.yml
+++ b/.github/workflows/Windows_CI.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [ '3.13' ]
+        python-version: [ '3.13', '3.14' ]
     name: Python ${{ matrix.python-version }} CI
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Closes #1291.

The Linux, macOS and Windows workflows all pin the matrix to `'3.13'`, so nothing in the repository reported whether the project runs on 3.14. This adds `'3.14'` alongside it in all three, and changes nothing else.

## Result

No dependency bump or source change is needed. With `requirements/requirements.txt` untouched — numpy 2.3.5, scipy 1.17.1, matplotlib 3.11.0, cvxpy 1.8.1, ecos 2.0.14 — the full suite passes on 3.14:

| OS | Python 3.13 | Python 3.14 |
| --- | --- | --- |
| Linux | pass | pass |
| macOS | pass | pass |
| Windows | pass | pass |

Measured on a fork of this repository at this commit, running `runtests.sh` unchanged.

I expected `ecos` to be the blocker, since it is a C extension and the most likely one to lack a 3.14 wheel, which would have failed the install step rather than a test. That did not happen — it installs and the suite passes, so the answer to #1291 turns out to be simply that the matrix had not been asked the question yet.

Happy to drop 3.13 instead of running both if you would rather the matrix stay at a single version.