### PR TITLE
Fix Reeds-Shepp planning at singular poses

### DIFF
--- a/PathPlanning/ReedsSheppPath/reeds_shepp_path_planning.py
+++ b/PathPlanning/ReedsSheppPath/reeds_shepp_path_planning.py
@@ -72,8 +72,9 @@ def set_path(paths, lengths, ctypes, step_size):
         if type_is_same and length_is_close:
             return paths  # same path found, so do not insert path
 
-    # check path is long enough
-    if path.L <= step_size:
+    # Keep a stationary solution, but discard nonzero paths that are shorter
+    # than the interpolation step.
+    if 0.0 < path.L <= step_size:
         return paths  # too short, so do not insert path
 
     paths.append(path)
@@ -147,8 +148,8 @@ def left_right_x_left(x, y, phi):
     u1, theta = polar(zeta, eeta)
 
     if u1 <= 4.0:
-        u = math.acos(1 - u1**2 * 0.125)
-        A = math.asin(2 * math.sin(u) / u1)
+        u = 2.0 * math.asin(0.25 * u1)
+        A = math.acos(0.25 * u1)
         t = mod2pi(-A + theta + math.pi/2)
         v = mod2pi(t - u - phi)
         return True, [t, u, -v], ['L', 'R', 'L']

--- a/tests/test_reeds_shepp_path_planning.py
+++ b/tests/test_reeds_shepp_path_planning.py
@@ -53,5 +53,33 @@ def test2():
         check_path_length(px, py, lengths)
 
 
+def test_identical_start_and_goal_pose():
+    for pose in [(0.0, 0.0, 0.0), (1.2, -3.4, 0.7)]:
+        px, py, pyaw, _, lengths = m.reeds_shepp_path_planning(
+            *pose, *pose, maxc=1.0
+        )
+
+        assert sum(np.abs(lengths)) == 0.0
+        assert np.all(np.isfinite(px))
+        assert np.all(np.isfinite(py))
+        assert np.all(np.isfinite(pyaw))
+        assert np.all(np.isfinite(lengths))
+        np.testing.assert_allclose(px, pose[0], atol=1e-10)
+        np.testing.assert_allclose(py, pose[1], atol=1e-10)
+        np.testing.assert_allclose(pyaw, pose[2], atol=1e-10)
+
+
+def test_near_singular_path_formula():
+    for distance in [1e-6, 1e-12]:
+        is_valid, lengths, modes = m.left_right_x_left(
+            distance, 0.0, 0.0
+        )
+
+        assert is_valid
+        assert np.all(np.isfinite(lengths))
+        np.testing.assert_allclose(lengths[1], distance / 2.0, rtol=1e-12)
+        assert modes == ["L", "R", "L"]
+
+
 if __name__ == '__main__':
     conftest.run_this_test(__file__)


### PR DESCRIPTION
#### Reference issue

N/A — I could not find an existing issue or pull request covering this singular Reeds–Shepp case.

#### What does this implement/fix?

This fixes the `left_right_x_left` Reeds–Shepp path formula at identical and nearly identical poses.

The existing computation uses:

```python
u = acos(1 - u1**2 / 8)
A = asin(2 * sin(u) / u1)
```

At `u1 == 0`, the second expression divides by zero. For small nonzero `u1`, subtracting `u1**2 / 8` from `1.0` loses precision. This can either move the `asin` argument outside its valid interval or collapse `u` to zero and produce a large, discontinuous path.

I replaced the expressions with the algebraically equivalent identities:

```python
u = 2 * asin(u1 / 4)
A = acos(u1 / 4)
```

For `0 <= u1 <= 4`, these preserve the original geometry while avoiding cancellation and division by `u1`.

The path-selection filter now also retains an exactly zero-length candidate. Nonzero paths shorter than the interpolation step are still discarded as before. Keeping the zero-length candidate ensures that identical start and goal poses select a stationary path instead of rejecting the correct solution.

#### Additional information

Before the fix:

- identical poses raise `ZeroDivisionError`;
- a displacement of `1e-6` raises `ValueError: math domain error`;
- a displacement of `1e-12` produces two turns of approximately `pi / 2` instead of a path converging to zero.

After the fix:

- identical poses return a finite zero-length path at the requested pose;
- the `1e-6` and `1e-12` cases remain finite and continuous;
- the middle LRL segment is approximately half the displacement, as expected from the stable formula.

Validation performed with Python 3.13.15:

- `pytest -q`: 139 passed
- Ruff checks passed
- mypy passed for all 122 `PathPlanning` source files
- `git diff --check` passed

#### CheckList

- [x] Added regression tests for the defect
- [x] Documentation is not applicable because this fixes an existing algorithm without adding a new example or changing its public interface
- [ ] GitHub CI pending
