### PR TITLE
Fix Dijkstra failure when goal is unreachable

### DIFF
--- a/PathPlanning/Dijkstra/dijkstra.py
+++ b/PathPlanning/Dijkstra/dijkstra.py
@@ -72,6 +72,10 @@ class DijkstraPlanner:
         open_set[self.calc_index(start_node)] = start_node
 
         while True:
+            if len(open_set) == 0:
+                print("Open set is empty..")
+                return [], []
+
             c_id = min(open_set, key=lambda o: open_set[o].cost)
             current = open_set[c_id]
 

--- a/tests/test_dijkstra.py
+++ b/tests/test_dijkstra.py
@@ -7,5 +7,20 @@ def test_1():
     m.main()
 
 
+def test_unreachable_goal():
+    m.show_animation = False
+
+    ox, oy = [], []
+    for i in range(7):
+        ox.extend([0.0, 6.0, float(i), float(i), 3.0])
+        oy.extend([float(i), float(i), 0.0, 6.0, float(i)])
+
+    planner = m.DijkstraPlanner(ox, oy, 1.0, 0.0)
+    rx, ry = planner.planning(1.0, 3.0, 5.0, 3.0)
+
+    assert rx == []
+    assert ry == []
+
+
 if __name__ == '__main__':
     conftest.run_this_test(__file__)


### PR DESCRIPTION
## Summary
- handle an exhausted open set in the Dijkstra planner
- return empty path lists instead of raising `ValueError`
- add a regression test with a goal separated by a solid obstacle wall

## Problem
When the goal is unreachable, Dijkstra eventually exhausts `open_set`. The next call to `min(open_set, ...)` then raises `ValueError: min() arg is an empty sequence`.

Other grid-search implementations in this repository already guard against an empty open set. This change adds equivalent handling to Dijkstra and returns `([], [])` to make the no-path result explicit.

## Tests
Added `test_unreachable_goal` in `tests/test_dijkstra.py` to verify that an unreachable goal returns empty path lists without throwing an exception.