### PR TITLE
Return empty path when road-map Dijkstra cannot reach goal

### DIFF
--- a/PathPlanning/VoronoiRoadMap/dijkstra_search.py
+++ b/PathPlanning/VoronoiRoadMap/dijkstra_search.py
@@ -59,7 +59,7 @@ class DijkstraSearch:
                 break
             elif not open_set:
                 print("Cannot find path")
-                break
+                return [], []
 
             current_id = min(open_set, key=lambda o: open_set[o].cost)
             current_node = open_set[current_id]

--- a/tests/test_voronoi_dijkstra_search.py
+++ b/tests/test_voronoi_dijkstra_search.py
@@ -1,0 +1,18 @@
+import conftest  # Add root path to sys.path
+from PathPlanning.VoronoiRoadMap.dijkstra_search import DijkstraSearch
+
+
+def test_unreachable_goal_returns_empty_path():
+    node_x = [0.0, 1.0, 2.0]
+    node_y = [0.0, 0.0, 0.0]
+    edge_ids_list = [[1], [0], []]
+
+    rx, ry = DijkstraSearch(False).search(
+        0.0, 0.0, 2.0, 0.0, node_x, node_y, edge_ids_list)
+
+    assert rx == []
+    assert ry == []
+
+
+if __name__ == '__main__':
+    conftest.run_this_test(__file__)


### PR DESCRIPTION
## Summary
- return `([], [])` when the shared road-map Dijkstra search exhausts its frontier
- add a deterministic regression test for an unreachable goal

## Problem
`PathPlanning/VoronoiRoadMap/dijkstra_search.py` is shared by the Voronoi and visibility road-map planners. When no path exists, the search currently breaks out of the loop and then calls `generate_final_path()` with the untouched goal node. That produces a singleton `[goal]` path, which can be mistaken for a successful plan.

This change makes the no-path result explicit and consistent with other planners in the repository by returning empty coordinate lists as soon as the open set is exhausted.

## Tests
Added `tests/test_voronoi_dijkstra_search.py` with a disconnected three-node graph and asserts that an unreachable goal returns empty path lists.