### PR TITLE
Handle goal node at index zero in RRT Dubins

### DIFF
--- a/PathPlanning/RRTDubins/rrt_dubins.py
+++ b/PathPlanning/RRTDubins/rrt_dubins.py
@@ -89,13 +89,13 @@ class RRTDubins(RRT):
 
             if (not search_until_max_iter) and new_node:  # check reaching the goal
                 last_index = self.search_best_goal_node()
-                if last_index:
+                if last_index is not None:
                     return self.generate_final_course(last_index)
 
         print("reached max iteration")
 
         last_index = self.search_best_goal_node()
-        if last_index:
+        if last_index is not None:
             return self.generate_final_course(last_index)
         else:
             print("Cannot find path")
@@ -141,7 +141,6 @@ class RRTDubins(RRT):
         new_node.x = px[-1]
         new_node.y = py[-1]
         new_node.yaw = pyaw[-1]
-
         new_node.path_x = px
         new_node.path_y = py
         new_node.path_yaw = pyaw

--- a/PathPlanning/RRTDubins/rrt_dubins.py
+++ b/PathPlanning/RRTDubins/rrt_dubins.py
@@ -141,6 +141,7 @@ class RRTDubins(RRT):
         new_node.x = px[-1]
         new_node.y = py[-1]
         new_node.yaw = pyaw[-1]
+
         new_node.path_x = px
         new_node.path_y = py
         new_node.path_yaw = pyaw

--- a/tests/test_rrt_dubins.py
+++ b/tests/test_rrt_dubins.py
@@ -7,5 +7,21 @@ def test1():
     m.main()
 
 
+def test_start_already_satisfies_goal():
+    planner = m.RRTDubins(
+        start=[0.0, 0.0, 0.0],
+        goal=[0.0, 0.0, 0.0],
+        obstacle_list=[],
+        rand_area=[-1.0, 1.0],
+        max_iter=0,
+    )
+
+    path = planner.planning(animation=False)
+
+    assert path is not None
+    assert path[0] == [0.0, 0.0]
+    assert path[-1] == [0.0, 0.0]
+
+
 if __name__ == '__main__':
     conftest.run_this_test(__file__)


### PR DESCRIPTION
## Summary
- treat goal index `0` as a valid search result in `RRTDubins`
- add a deterministic regression test where the start already satisfies the goal pose

## Problem
`search_best_goal_node()` returns a node index or `None`. The planner currently checks the result with `if last_index:`, so a valid result of `0` is treated as false and the planner incorrectly reports that no path was found.

This occurs naturally when the start node itself already satisfies the goal position and yaw thresholds.

## Fix
Use an explicit `is not None` check for the returned node index.

## Tests
Added `test_start_already_satisfies_goal` with `max_iter=0`, which makes node index `0` the valid goal result and verifies that planning returns a path.