### PR TITLE
Handle failed LQR local paths in LQR-RRT* steering

### DIFF
--- a/PathPlanning/LQRRRTStar/lqr_rrt_star.py
+++ b/PathPlanning/LQRRRTStar/lqr_rrt_star.py
@@ -190,7 +190,7 @@ class LQRRRTStar(RRTStar):
 
         px, py, course_lens = self.sample_path(wx, wy, self.step_size)
 
-        if px is None:
+        if not px:
             return None
 
         newNode = copy.deepcopy(from_node)

--- a/tests/test_lqr_rrt_star.py
+++ b/tests/test_lqr_rrt_star.py
@@ -10,5 +10,19 @@ def test1():
     m.main(maxIter=5)
 
 
+def test_steer_handles_failed_local_planner():
+    planner = m.LQRRRTStar(
+        start=[0.0, 0.0],
+        goal=[1.0, 1.0],
+        obstacle_list=[],
+        rand_area=[-1.0, 1.0],
+    )
+    planner.lqr_planner.lqr_planning = lambda *args, **kwargs: ([], [])
+
+    result = planner.steer(planner.start, planner.end)
+
+    assert result is None
+
+
 if __name__ == '__main__':
     conftest.run_this_test(__file__)

--- a/tests/test_lqr_rrt_star.py
+++ b/tests/test_lqr_rrt_star.py
@@ -17,7 +17,7 @@ def test_steer_handles_failed_local_planner():
         obstacle_list=[],
         rand_area=[-1.0, 1.0],
     )
-    planner.lqr_planner.lqr_planning = lambda *args, **kwargs: ([], [])
+    planner.lqr_planner.MAX_TIME = 0.0
 
     result = planner.steer(planner.start, planner.end)
 


### PR DESCRIPTION
## Summary
- handle an empty local path returned by the LQR planner
- return `None` from `LQRRRTStar.steer()` instead of indexing an empty list
- add a deterministic regression test using the real LQR failure path

## Problem
`LQRPlanner.lqr_planning()` explicitly returns `([], [])` when it cannot find a path. `LQRRRTStar.steer()` currently checks only `if px is None`, so an empty list passes the check and the subsequent `px[-1]` / `py[-1]` access raises `IndexError`.

## Fix
Treat an empty sampled path as a failed steering attempt with `if not px: return None`. This matches the existing planner convention that `None` indicates steering failure and lets the RRT* search continue safely.

## Tests
Added `test_steer_handles_failed_local_planner`. The test uses the real `LQRPlanner` with `MAX_TIME = 0.0`, which deterministically exercises its existing no-path return `([], [])`, and verifies that `steer()` returns `None` without raising.