### PR TITLE
Wrap yaw error when checking Reeds-Shepp goal pose

### DIFF
--- a/PathPlanning/RRTStarReedsShepp/rrt_star_reeds_shepp.py
+++ b/PathPlanning/RRTStarReedsShepp/rrt_star_reeds_shepp.py
@@ -200,7 +200,9 @@ class RRTStarReedsShepp(RRTStar):
         # angle check
         final_goal_indexes = []
         for i in goal_indexes:
-            if abs(self.node_list[i].yaw - self.end.yaw) <= self.goal_yaw_th:
+            yaw_diff = self.node_list[i].yaw - self.end.yaw
+            yaw_error = math.atan2(math.sin(yaw_diff), math.cos(yaw_diff))
+            if abs(yaw_error) <= self.goal_yaw_th:
                 final_goal_indexes.append(i)
 
         print("final_goal_indexes:", len(final_goal_indexes))

--- a/tests/test_rrt_star_reeds_shepp.py
+++ b/tests/test_rrt_star_reeds_shepp.py
@@ -42,5 +42,21 @@ def test_too_big_step_size():
     assert path is None
 
 
+def test_goal_yaw_wraparound():
+    yaw_offset = 0.005
+    planner = m.RRTStarReedsShepp(
+        start=[0.0, 0.0, m.math.pi - yaw_offset],
+        goal=[0.0, 0.0, -m.math.pi + yaw_offset],
+        obstacle_list=[],
+        rand_area=[-1.0, 1.0],
+        max_iter=0,
+    )
+    planner.node_list = [planner.start]
+
+    goal_index = planner.search_best_goal_node()
+
+    assert goal_index == 0
+
+
 if __name__ == '__main__':
     conftest.run_this_test(__file__)


### PR DESCRIPTION
## Summary
- compute the shortest signed angular difference for Reeds-Shepp goal checks
- handle the `-pi` / `+pi` wraparound correctly
- add a deterministic regression test at the angle boundary

## Problem
`RRTStarReedsShepp.search_best_goal_node()` currently checks the goal yaw with a direct subtraction:

```python
abs(node.yaw - self.end.yaw) <= self.goal_yaw_th
```

Angles are periodic, so poses near opposite sides of the `-pi` / `+pi` representation boundary can be physically very close while their raw numeric difference is almost `2*pi`.

For example, `pi - 0.005` and `-pi + 0.005` differ by only `0.01 rad` on the circle, which is within the planner's 1-degree goal threshold, but the current check sees a difference of about `6.273 rad` and rejects the node.

## Fix
Compute the wrapped signed angle using `atan2(sin(diff), cos(diff))` before applying the existing threshold.

## Tests
Added `test_goal_yaw_wraparound`, which places the start and goal at the same position with headings straddling the `-pi` / `+pi` boundary and verifies that the start node is accepted as satisfying the goal yaw threshold.